### PR TITLE
Use NuGet.config instead of manual configuration of package sources

### DIFF
--- a/ApplicationInsights.AspNet.sln
+++ b/ApplicationInsights.AspNet.sln
@@ -8,6 +8,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{62AD20FD-640F-4F99-94EF-96A7581F1CF9}"
 	ProjectSection(SolutionItems) = preProject
 		global.json = global.json
+		NuGet.config = NuGet.config
+		Readme.md = Readme.md
 	EndProjectSection
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "ApplicationInsights.AspNet", "src\ApplicationInsights.AspNet\ApplicationInsights.AspNet.kproj", "{95EC3635-22E4-4C3A-A066-F5823A0648DA}"

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="ASP.NET vNext" value="https://www.myget.org/F/aspnetvnext/api/v2/" />
+    <add key="Application Insights" value="http://appinsights-aspnet.azurewebsites.net/nuget/" />
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+  </packageSources>
+</configuration>

--- a/Readme.md
+++ b/Readme.md
@@ -86,12 +86,6 @@ Developing
  - *(recommended by [Anastasia](https://github.com/abaranch))*: http://blogs.msdn.com/b/visualstudioalm/archive/2014/06/04/visual-studio-14-ctp-now-available-in-the-virtual-machine-azure-gallery.aspx
  - You can just install it on your machine: https://www.visualstudio.com/en-us/news/vs2015-vs.aspx
 
-
-4. Make sure you have these (only these and in this order) feeds configured in Visual Studio. You may need to restart Visual Studio to allow packages to be restored correctly:
- - https://www.myget.org/F/aspnetvnext
- - http://appinsights-aspnet.azurewebsites.net/nuget/
- - https://www.nuget.org/api/v2/
-
 Running and writing tests
 -------------------------
 There are two sets of tests unit tests and functional tests. Please use unit tests for all features testing. The purpose of functional tests is just end-to-end validation of functionality on sample applications.


### PR DESCRIPTION
Introduces NuGet.config and removes the now unnecessary description of the manual configuration of package sources from the Readme.md.
