### PR TITLE
Resolve ITelemetryChannel service from DI Container

### DIFF
--- a/src/ApplicationInsights.AspNet/ApplicationInsightsExtensions.cs
+++ b/src/ApplicationInsights.AspNet/ApplicationInsightsExtensions.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using Microsoft.ApplicationInsights.AspNet.ContextInitializers;
     using Microsoft.ApplicationInsights.AspNet.TelemetryInitializers;
+    using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.AspNet.Builder;
@@ -50,6 +51,7 @@
             {
                 var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
                 AddInstrumentationKey(config, telemetryConfiguration);
+                telemetryConfiguration.TelemetryChannel = serviceProvider.GetService<ITelemetryChannel>() ?? telemetryConfiguration.TelemetryChannel;
                 AddServicesToCollection(serviceProvider, telemetryConfiguration.ContextInitializers);
                 AddServicesToCollection(serviceProvider, telemetryConfiguration.TelemetryInitializers);
                 return telemetryConfiguration;


### PR DESCRIPTION
This changes the `AddApplicationInsightsTelemetry` extension method to automatically resolve the `ITelemetryChannel` service from the DI container when constructing the `TelemetryConfiguration` service instance. If the service is not available, the default telemetry channel instance is preserved. 

We wanted to add this capability to simplify unit testing for our customers and allow them to replace telemetry channel in their tests more easily. However, using DI containers in unit tests is an anti-pattern because it turns them into fragile _integration_ tests. Because of that, I think that we should not suggest that customers test their apps this way. Instead, we should explain how to create a `TelemetryClient` instance with an `ITelemetryChannel` mock and work with Josh to offer better support for this scenario in the Core API.

cc: @SergKanz 
