### PR TITLE
Sergkanz/eventsource

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNet/ContextInitializers/DomainNameRoleInstanceContextInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/ContextInitializers/DomainNameRoleInstanceContextInitializer.cs
@@ -31,7 +31,7 @@
         {
             if (context == null)
             {
-                this.eventSource.VerboseTelemetryContextNotAvailableInContextInitializer();
+                this.eventSource.TelemetryContextNotAvailableInContextInitializer();
                 return;
             }
 

--- a/src/Microsoft.ApplicationInsights.AspNet/ContextInitializers/DomainNameRoleInstanceContextInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/ContextInitializers/DomainNameRoleInstanceContextInitializer.cs
@@ -6,6 +6,7 @@
     using System.Net.NetworkInformation;
     using System.Threading;
 
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
 
@@ -16,6 +17,13 @@
     {
         private string roleInstanceName;
 
+        private readonly AspNet5EventSource eventSource;
+
+        public DomainNameRoleInstanceContextInitializer(AspNet5EventSource eventSource)
+        {
+            this.eventSource = eventSource;
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DomainNameRoleInstanceContextInitializer"/> class.
         /// </summary>
@@ -23,7 +31,8 @@
         {
             if (context == null)
             {
-                // TODO: add diagnostics
+                this.eventSource.VerboseTelemetryContextNotAvailableInContextInitializer();
+                return;
             }
 
             if (string.IsNullOrEmpty(context.Device.RoleInstance))

--- a/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
@@ -7,6 +7,7 @@
     using Microsoft.ApplicationInsights.AspNet;
     using Microsoft.ApplicationInsights.AspNet.ContextInitializers;
     using Microsoft.ApplicationInsights.AspNet.TelemetryInitializers;
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
@@ -35,6 +36,8 @@
 
         public static void AddApplicationInsightsTelemetry(this IServiceCollection services, IConfiguration config)
         {
+            services.AddSingleton<AspNet5EventSource>();
+
             services.AddSingleton<IContextInitializer, DomainNameRoleInstanceContextInitializer>();
 
             services.AddSingleton<ITelemetryInitializer, ClientIpHeaderTelemetryInitializer>();

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/ClientIpHeaderTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/ClientIpHeaderTelemetryInitializer.cs
@@ -9,6 +9,8 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.AspNet.Hosting;
     using Microsoft.AspNet.Http;
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
+
 
 
     /// <summary>
@@ -25,8 +27,8 @@
         private readonly ICollection<string> headerNames;
 
 
-        public ClientIpHeaderTelemetryInitializer(IHttpContextAccessor httpContextAccessor)
-             : base(httpContextAccessor)
+        public ClientIpHeaderTelemetryInitializer(IHttpContextAccessor httpContextAccessor, AspNet5EventSource eventSource)
+             : base(httpContextAccessor, eventSource)
         {
             this.headerNames = new List<string>();
             this.HeaderNames.Add(HeaderNameDefault);

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/OperationIdTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/OperationIdTelemetryInitializer.cs
@@ -5,10 +5,12 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.AspNet.Http;
     using Microsoft.AspNet.Hosting;
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
 
     public class OperationIdTelemetryInitializer : TelemetryInitializerBase
     {
-        public OperationIdTelemetryInitializer(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+        public OperationIdTelemetryInitializer(IHttpContextAccessor httpContextAccessor, AspNet5EventSource eventSource)
+             : base(httpContextAccessor, eventSource)
         { }
 
         protected override void OnInitializeTelemetry(HttpContext platformContext, RequestTelemetry requestTelemetry, ITelemetry telemetry)

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/OperationNameTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/OperationNameTelemetryInitializer.cs
@@ -10,10 +10,12 @@
     using Microsoft.AspNet.Mvc;
     using Microsoft.AspNet.Mvc.Routing;
     using Microsoft.Framework.DependencyInjection;
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
 
     public class OperationNameTelemetryInitializer : TelemetryInitializerBase
     {
-        public OperationNameTelemetryInitializer(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+        public OperationNameTelemetryInitializer(IHttpContextAccessor httpContextAccessor, AspNet5EventSource eventSource)
+             : base(httpContextAccessor, eventSource)
         { }
 
         protected override void OnInitializeTelemetry(HttpContext platformContext, RequestTelemetry requestTelemetry, ITelemetry telemetry)

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/TelemetryInitializerBase.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/TelemetryInitializerBase.cs
@@ -9,6 +9,7 @@
     using Microsoft.AspNet.Hosting;
     using Microsoft.AspNet.Http;
     using Microsoft.Framework.DependencyInjection;
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
 
     public abstract class TelemetryInitializerBase : ITelemetryInitializer
     {
@@ -32,7 +33,7 @@
 
                 if (context == null)
                 {
-                    //TODO: Diagnostics!
+                    Aspnet5EventSource.Log.TelemetryInitializerNotEnabledOnHttpContextNull();
                     return;
                 }
 

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/TelemetryInitializerBase.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/TelemetryInitializerBase.cs
@@ -37,20 +37,20 @@
                 var context = this.httpContextAccessor.HttpContext;
                 if (context == null)
                 {
-                    this.eventSource.VerboseTelemetryInitializerNotEnabledOnHttpContextNull();
+                    this.eventSource.TelemetryInitializerNotEnabledOnHttpContextNull();
                     return;
                 }
 
                 if (context.RequestServices == null)
                 {
-                    this.eventSource.VerboseTelemetryInitializerNotEnabledOnRequestServicesNull();
+                    this.eventSource.TelemetryInitializerNotEnabledOnRequestServicesNull();
                     return;
                 }
 
                 var request = context.RequestServices.GetService<RequestTelemetry>();
                 if (request == null)
                 {
-                    this.eventSource.UserActionableErrorRegisterApplicationInsightsServices();
+                    this.eventSource.RegisterApplicationInsightsServices();
                     return;
                 }
 
@@ -58,7 +58,7 @@
             }
             catch (Exception exp)
             {
-                this.eventSource.ErrorTelemetryInitializerFailedToCollectData(exp);
+                this.eventSource.TelemetryInitializerFailedToCollectData(exp);
             }
         }
 

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/TelemetryInitializerBase.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/TelemetryInitializerBase.cs
@@ -15,7 +15,9 @@
     {
         private IHttpContextAccessor httpContextAccessor;
 
-        public TelemetryInitializerBase(IHttpContextAccessor httpContextAccessor)
+        private readonly AspNet5EventSource eventSource;
+
+        public TelemetryInitializerBase(IHttpContextAccessor httpContextAccessor, AspNet5EventSource eventSource)
         {
             if (httpContextAccessor == null)
             {
@@ -23,6 +25,9 @@
             }
 
             this.httpContextAccessor = httpContextAccessor;
+
+            //Event source may never be null as it will be injected by DI.
+            this.eventSource = eventSource;
         }
 
         public void Initialize(ITelemetry telemetry)
@@ -30,10 +35,10 @@
             try
             {
                 var context = this.httpContextAccessor.HttpContext;
-
+                this.eventSource.TelemetryInitializerNotEnabledOnHttpContextNull();
                 if (context == null)
                 {
-                    Aspnet5EventSource.Log.TelemetryInitializerNotEnabledOnHttpContextNull();
+                    this.eventSource.TelemetryInitializerNotEnabledOnHttpContextNull();
                     return;
                 }
 

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/TelemetryInitializerBase.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/TelemetryInitializerBase.cs
@@ -35,24 +35,22 @@
             try
             {
                 var context = this.httpContextAccessor.HttpContext;
-                this.eventSource.TelemetryInitializerNotEnabledOnHttpContextNull();
                 if (context == null)
                 {
-                    this.eventSource.TelemetryInitializerNotEnabledOnHttpContextNull();
+                    this.eventSource.VerboseTelemetryInitializerNotEnabledOnHttpContextNull();
                     return;
                 }
 
                 if (context.RequestServices == null)
                 {
-                    //TODO: Diagnostics!
+                    this.eventSource.VerboseTelemetryInitializerNotEnabledOnRequestServicesNull();
                     return;
                 }
 
                 var request = context.RequestServices.GetService<RequestTelemetry>();
-
                 if (request == null)
                 {
-                    //TODO: Diagnostics!
+                    this.eventSource.UserActionableErrorRegisterApplicationInsightsServices();
                     return;
                 }
 
@@ -60,8 +58,7 @@
             }
             catch (Exception exp)
             {
-                //TODO: Diagnostics!
-                Debug.WriteLine(exp);
+                this.eventSource.ErrorTelemetryInitializerFailedToCollectData(exp);
             }
         }
 

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/UserAgentTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/UserAgentTelemetryInitializer.cs
@@ -7,6 +7,8 @@
     using Microsoft.AspNet.Hosting;
     using Microsoft.AspNet.Http;
     using Microsoft.Net.Http.Headers;
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
+
 
     /// <summary>
     /// Telemetry initializer populates user agent (telemetry.Context.User.UserAgent) for 
@@ -14,7 +16,8 @@
     /// </summary>
     public class UserAgentTelemetryInitializer : TelemetryInitializerBase
     {
-        public UserAgentTelemetryInitializer(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+        public UserAgentTelemetryInitializer(IHttpContextAccessor httpContextAccessor, AspNet5EventSource eventSource)
+             : base(httpContextAccessor, eventSource)
         {
         }
 

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/WebSessionTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/WebSessionTelemetryInitializer.cs
@@ -57,7 +57,7 @@
 
                 if (!cookieWasRead)
                 {
-                    this.eventSource.ErrorMalformedCookie(WebSessionCookieName, sessionCookieValue);
+                    this.eventSource.MalformedCookie(WebSessionCookieName, sessionCookieValue);
                 }
             }
         }

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/WebSessionTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/WebSessionTelemetryInitializer.cs
@@ -5,13 +5,14 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.AspNet.Hosting;
     using Microsoft.AspNet.Http;
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
 
     public class WebSessionTelemetryInitializer : TelemetryInitializerBase
     {
         private const string WebSessionCookieName = "ai_session";
 
-        public WebSessionTelemetryInitializer(IHttpContextAccessor httpContextAccessor)
-             : base(httpContextAccessor)
+        public WebSessionTelemetryInitializer(IHttpContextAccessor httpContextAccessor, AspNet5EventSource eventSource)
+             : base(httpContextAccessor, eventSource)
         {
         }
 

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/WebSessionTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/WebSessionTelemetryInitializer.cs
@@ -51,6 +51,7 @@
                         // Currently SessionContext takes in only SessionId. 
                         // The cookies has SessionAcquisitionDate and SessionRenewDate as well that we are not picking for now.
                         requestTelemetry.Context.Session.Id = sessionCookieParts[0];
+                        cookieWasRead = true;
                     }
                 }
 

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/WebUserTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/WebUserTelemetryInitializer.cs
@@ -68,7 +68,7 @@
 
                 if (!cookieWasRead)
                 {
-                    this.eventSource.ErrorMalformedCookie(WebUserCookieName, userCookieValue);
+                    this.eventSource.MalformedCookie(WebUserCookieName, userCookieValue);
                 }
             }
         }

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/WebUserTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/WebUserTelemetryInitializer.cs
@@ -6,13 +6,14 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.AspNet.Hosting;
     using Microsoft.AspNet.Http;
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
 
     public class WebUserTelemetryInitializer : TelemetryInitializerBase
     {
         private const string WebUserCookieName = "ai_user";
 
-        public WebUserTelemetryInitializer(IHttpContextAccessor httpContextAccessor)
-             : base(httpContextAccessor)
+        public WebUserTelemetryInitializer(IHttpContextAccessor httpContextAccessor, AspNet5EventSource eventSource)
+             : base(httpContextAccessor, eventSource)
         {
         }
 

--- a/src/Microsoft.ApplicationInsights.AspNet/Tracing/Aspnet5EventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Tracing/Aspnet5EventSource.cs
@@ -1,0 +1,34 @@
+﻿namespace Microsoft.ApplicationInsights.AspNet.Tracing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Tracing;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    internal class Aspnet5EventSource : EventSource
+    {
+        /// <summary>
+        /// Instance of the Aspnet5EventSource class.
+        /// </summary>
+        public static readonly Aspnet5EventSource Log = new Aspnet5EventSource();
+
+        private Aspnet5EventSource()
+        {
+        }
+
+        [Event(1, Message = "TelemetryInitializerNotEnabledOnHttpContextNull", Level = EventLevel.Verbose)]
+        public void TelemetryInitializerNotEnabledOnHttpContextNull()
+        {
+            this.WriteEvent(1);
+        }
+
+        public sealed class Keywords
+        {
+            /// <summary>
+            /// Key word for user actionable events.
+            /// </summary>
+            public const EventKeywords UserActionable = (EventKeywords)0x1;            
+        }
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNet/Tracing/Aspnet5EventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Tracing/Aspnet5EventSource.cs
@@ -1,23 +1,15 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNet.Tracing
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.Tracing;
-    using System.Linq;
-    using System.Threading.Tasks;
 
-    internal class Aspnet5EventSource : EventSource
+    [EventSource(Name = "Microsoft-ApplicationInsights-AspNet5")]
+    public class AspNet5EventSource : EventSource
     {
-        /// <summary>
-        /// Instance of the Aspnet5EventSource class.
-        /// </summary>
-        public static readonly Aspnet5EventSource Log = new Aspnet5EventSource();
-
-        private Aspnet5EventSource()
+        public AspNet5EventSource()
         {
         }
 
-        [Event(1, Message = "TelemetryInitializerNotEnabledOnHttpContextNull", Level = EventLevel.Verbose)]
+        [Event(1, Message = "Telemetry Initializer is not enabled when HttpContext is null", Level = EventLevel.Verbose)]
         public void TelemetryInitializerNotEnabledOnHttpContextNull()
         {
             this.WriteEvent(1);

--- a/src/Microsoft.ApplicationInsights.AspNet/Tracing/Aspnet5EventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Tracing/Aspnet5EventSource.cs
@@ -11,44 +11,44 @@
         }
 
         [Event(1, Message = "Telemetry Initializer will not collect data when HttpContext is null.", Level = EventLevel.Verbose)]
-        public void VerboseTelemetryInitializerNotEnabledOnHttpContextNull()
+        public void TelemetryInitializerNotEnabledOnHttpContextNull()
         {
             this.WriteEvent(1);
         }
 
         [Event(2, Message = "Telemetry Initializer will not collect data when RequestServices are not available.", Level = EventLevel.Verbose)]
-        public void VerboseTelemetryInitializerNotEnabledOnRequestServicesNull()
+        public void TelemetryInitializerNotEnabledOnRequestServicesNull()
         {
             this.WriteEvent(2);
         }
 
         [NonEvent]
-        public void ErrorTelemetryInitializerFailedToCollectData(Exception exception)
+        public void TelemetryInitializerFailedToCollectData(Exception exception)
         {
-            this.ErrorTelemetryInitializerFailedToCollectData(exception.ToString());
+            this.TelemetryInitializerFailedToCollectData(exception.ToString());
         }
 
         [Event(3, Message = "Telemetry Initializer failed to collect data. Exception: {0}", Level = EventLevel.Error)]
-        public void ErrorTelemetryInitializerFailedToCollectData(string exception)
+        public void TelemetryInitializerFailedToCollectData(string exception)
         {
             this.WriteEvent(3, exception);
         }
 
         [Event(4, Message = "TelemetryContext is null in context initializer.", Level = EventLevel.Verbose)]
-        public void VerboseTelemetryContextNotAvailableInContextInitializer()
+        public void TelemetryContextNotAvailableInContextInitializer()
         {
             this.WriteEvent(4);
         }
 
         [Event(5, Message ="Malformed cookie {0}: value {1}. This may indicate misconfiguiration of JavaScript SDK.", Level = EventLevel.Error)]
-        public void ErrorMalformedCookie(string cookieName, string cookieValue)
+        public void MalformedCookie(string cookieName, string cookieValue)
         {
             this.WriteEvent(5);
         }
 
         [Event(10, Message = "Application Insights services should be registered. Use method AddApplicationInsightsTelemetry in application startup.", 
             Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
-        public void UserActionableErrorRegisterApplicationInsightsServices()
+        public void RegisterApplicationInsightsServices()
         {
             this.WriteEvent(10);
         }

--- a/src/Microsoft.ApplicationInsights.AspNet/Tracing/Aspnet5EventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Tracing/Aspnet5EventSource.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNet.Tracing
 {
+    using System;
     using System.Diagnostics.Tracing;
 
     [EventSource(Name = "Microsoft-ApplicationInsights-AspNet5")]
@@ -9,17 +10,48 @@
         {
         }
 
-        [Event(1, Message = "Telemetry Initializer is not enabled when HttpContext is null", Level = EventLevel.Verbose)]
-        public void TelemetryInitializerNotEnabledOnHttpContextNull()
+        [Event(1, Message = "Telemetry Initializer will not collect data when HttpContext is null.", Level = EventLevel.Verbose)]
+        public void VerboseTelemetryInitializerNotEnabledOnHttpContextNull()
         {
             this.WriteEvent(1);
         }
 
-        protected virtual void WriteEventEx(int eventId)
+        [Event(2, Message = "Telemetry Initializer will not collect data when RequestServices are not available.", Level = EventLevel.Verbose)]
+        public void VerboseTelemetryInitializerNotEnabledOnRequestServicesNull()
         {
-            this.WriteEvent(eventId);
+            this.WriteEvent(2);
         }
 
+        [NonEvent]
+        public void ErrorTelemetryInitializerFailedToCollectData(Exception exception)
+        {
+            this.ErrorTelemetryInitializerFailedToCollectData(exception.ToString());
+        }
+
+        [Event(3, Message = "Telemetry Initializer failed to collect data. Exception: {0}", Level = EventLevel.Error)]
+        public void ErrorTelemetryInitializerFailedToCollectData(string exception)
+        {
+            this.WriteEvent(3, exception);
+        }
+
+        [Event(4, Message = "TelemetryContext is null in context initializer.", Level = EventLevel.Verbose)]
+        public void VerboseTelemetryContextNotAvailableInContextInitializer()
+        {
+            this.WriteEvent(4);
+        }
+
+        [Event(5, Message ="Malformed cookie {0}: value {1}. This may indicate misconfiguiration of JavaScript SDK.", Level = EventLevel.Error)]
+        public void ErrorMalformedCookie(string cookieName, string cookieValue)
+        {
+            this.WriteEvent(5);
+        }
+
+        [Event(10, Message = "Application Insights services should be registered. Use method AddApplicationInsightsTelemetry in application startup.", 
+            Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
+        public void UserActionableErrorRegisterApplicationInsightsServices()
+        {
+            this.WriteEvent(10);
+        }
 
         public sealed class Keywords
         {

--- a/src/Microsoft.ApplicationInsights.AspNet/Tracing/Aspnet5EventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Tracing/Aspnet5EventSource.cs
@@ -15,6 +15,12 @@
             this.WriteEvent(1);
         }
 
+        protected virtual void WriteEventEx(int eventId)
+        {
+            this.WriteEvent(eventId);
+        }
+
+
         public sealed class Keywords
         {
             /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNet/project.json
+++ b/src/Microsoft.ApplicationInsights.AspNet/project.json
@@ -15,7 +15,8 @@
         "Microsoft.AspNet.Http.Interfaces": "1.0.0-beta4",
         "Microsoft.AspNet.Http.Extensions": "1.0.0-beta4",
         "Microsoft.AspNet.Mvc.Core": "6.0.0-beta4",
-        "Microsoft.Framework.Logging.Interfaces": "1.0.0-beta4"
+        "Microsoft.Framework.Logging.Interfaces": "1.0.0-beta4",
+        "System.Diagnostics.Tracing": "4.0.20-beta-22816"
     },
 
     "frameworks": {

--- a/test/FunctionalTestUtils/Aspnet5EventTestListener.cs
+++ b/test/FunctionalTestUtils/Aspnet5EventTestListener.cs
@@ -1,0 +1,73 @@
+﻿namespace Microsoft.ApplicationInsights.AspNet.Tests.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Diagnostics.Tracing;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Xunit.Abstractions;
+
+    public class Aspnet5EventTestListener : EventListener
+    {
+        private readonly List<EventWrittenEventArgs> events = new List<EventWrittenEventArgs>();
+
+        private static Func<EventWrittenEventArgs, bool> issueDefinition = (message) => {
+                return message.Level == EventLevel.Error
+                    || message.Level == EventLevel.Critical
+                    || message.Level == EventLevel.Warning;
+            };
+
+        private ITestOutputHelper output;
+
+        public Aspnet5EventTestListener(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        public IEnumerable<EventWrittenEventArgs> Events
+        {
+            get
+            {
+                return this.events;
+            }
+        }
+
+        public bool HasIssues
+        {
+            get
+            {
+                return this.Events.Where(issueDefinition).Count() > 0;
+            }
+        }
+
+        public string Issues
+        {
+            get
+            {
+                string issues = string.Empty;
+
+                Parallel.ForEach(this.Events.Where(issueDefinition), (message) => { issues += message.Message + Environment.NewLine; });
+
+                return issues;
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            output.WriteLine("Trace: " + eventData.Message);
+            this.events.Add(eventData);
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name.StartsWith("Microsoft-ApplicationInsights-", StringComparison.Ordinal))
+            {
+                this.EnableEvents(eventSource, EventLevel.LogAlways, (EventKeywords)(-1L));
+            }
+
+            base.OnEventSourceCreated(eventSource);
+        }
+
+    }
+}

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/ContextInitializers/DomainNameRoleInstanceContextInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/ContextInitializers/DomainNameRoleInstanceContextInitializerTests.cs
@@ -13,7 +13,7 @@
         [Fact]
         public void RoleInstanceNameIsSetToDomainAndHost()
         {
-            var source = new DomainNameRoleInstanceContextInitializer();
+            var source = new DomainNameRoleInstanceContextInitializer(null);
             var telemetryContext = new TelemetryContext();
 
             source.Initialize(telemetryContext);
@@ -34,7 +34,7 @@
         [Fact]
         public void ContextInitializerDoesNotOverrideMachineName()
         {
-            var source = new DomainNameRoleInstanceContextInitializer();
+            var source = new DomainNameRoleInstanceContextInitializer(null);
             var telemetryContext = new TelemetryContext();
             telemetryContext.Device.RoleInstance = "Test";
 

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -12,7 +12,8 @@
     using Microsoft.AspNet.Hosting;
     using Microsoft.Framework.ConfigurationModel;
     using Xunit;
-    
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
+
     public static class ApplicationInsightsExtensionsTests
     {
         public static ServiceCollection GetServiceCollectionWithContextAccessor()

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/ClientIpHeaderTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/ClientIpHeaderTelemetryInitializerTests.cs
@@ -21,7 +21,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
             
-            var initializer = new ClientIpHeaderTelemetryInitializer(ac, null);
+            var initializer = new ClientIpHeaderTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -31,7 +31,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
             
-            var initializer = new ClientIpHeaderTelemetryInitializer(ac, null);
+            var initializer = new ClientIpHeaderTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/ClientIpHeaderTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/ClientIpHeaderTelemetryInitializerTests.cs
@@ -7,6 +7,7 @@
     using Microsoft.AspNet.Hosting;
     using Microsoft.AspNet.Http.Core;
     using Xunit;
+    using System.Diagnostics.Tracing;
 
     public class ClientIpHeaderTelemetryInitializerTests
     {
@@ -20,7 +21,7 @@
         public void InitializeDoesNotThrowIfHttpContextIsUnavailable()
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
-            
+
             var initializer = new ClientIpHeaderTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
@@ -30,7 +31,7 @@
         public void InitializeDoesNotThrowIfRequestTelemetryIsUnavailable()
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
-            
+
             var initializer = new ClientIpHeaderTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/ClientIpHeaderTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/ClientIpHeaderTelemetryInitializerTests.cs
@@ -13,7 +13,7 @@
         [Fact]
         public void InitializeThrowIfHttpContextAccessorIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => { var initializer = new ClientIpHeaderTelemetryInitializer(null);  });
+            Assert.Throws<ArgumentNullException>(() => { var initializer = new ClientIpHeaderTelemetryInitializer(null, null);  });
         }
 
         [Fact]
@@ -21,7 +21,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
             
-            var initializer = new ClientIpHeaderTelemetryInitializer(ac);
+            var initializer = new ClientIpHeaderTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -31,7 +31,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
             
-            var initializer = new ClientIpHeaderTelemetryInitializer(ac);
+            var initializer = new ClientIpHeaderTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -43,7 +43,7 @@
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers.Add("X-Forwarded-For", new string[] { "127.0.0.3" });
 
-            var initializer = new ClientIpHeaderTelemetryInitializer(contextAccessor);
+            var initializer = new ClientIpHeaderTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(requestTelemetry);
 
@@ -57,7 +57,7 @@
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers.Add("HEADER", new string[] { "127.0.0.3;127.0.0.4" });
 
-            var initializer = new ClientIpHeaderTelemetryInitializer(contextAccessor);
+            var initializer = new ClientIpHeaderTelemetryInitializer(contextAccessor, null);
             initializer.HeaderNames.Add("HEADER");
             initializer.HeaderValueSeparators = ",;";
 
@@ -75,7 +75,7 @@
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers.Add("X-Forwarded-For", new string[] { "127.0.0.3" });
 
-            var initializer = new ClientIpHeaderTelemetryInitializer(contextAccessor);
+            var initializer = new ClientIpHeaderTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(requestTelemetry);
 

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationIdTelemetryInitializerTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationIdTelemetryInitializerTest.cs
@@ -13,7 +13,7 @@
         [Fact]
         public void InitializeThrowIfHttpContextAccessorIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => { var initializer = new OperationIdTelemetryInitializer(null); });
+            Assert.Throws<ArgumentNullException>(() => { var initializer = new OperationIdTelemetryInitializer(null, null); });
         }
 
         [Fact]
@@ -21,7 +21,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
 
-            var initializer = new OperationIdTelemetryInitializer(ac);
+            var initializer = new OperationIdTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -31,7 +31,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
 
-            var initializer = new OperationIdTelemetryInitializer(ac);
+            var initializer = new OperationIdTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -43,7 +43,7 @@
             telemetry.Context.Operation.Id = "123";
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor();
 
-            var initializer = new OperationIdTelemetryInitializer(contextAccessor);
+            var initializer = new OperationIdTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(telemetry);
 
@@ -57,7 +57,7 @@
             var requestTelemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
 
-            var initializer = new OperationIdTelemetryInitializer(contextAccessor);
+            var initializer = new OperationIdTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(telemetry);
 

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationIdTelemetryInitializerTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationIdTelemetryInitializerTest.cs
@@ -21,7 +21,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
 
-            var initializer = new OperationIdTelemetryInitializer(ac, null);
+            var initializer = new OperationIdTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -31,7 +31,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
 
-            var initializer = new OperationIdTelemetryInitializer(ac, null);
+            var initializer = new OperationIdTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -41,7 +41,8 @@
         {
             var telemetry = new EventTelemetry();
             telemetry.Context.Operation.Id = "123";
-            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor();
+            var requestTelemetry = new RequestTelemetry();
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
 
             var initializer = new OperationIdTelemetryInitializer(contextAccessor, null);
 

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
@@ -24,7 +24,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
 
-            var initializer = new OperationNameTelemetryInitializer(ac, null);
+            var initializer = new OperationNameTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -34,7 +34,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
 
-            var initializer = new OperationNameTelemetryInitializer(ac, null);
+            var initializer = new OperationNameTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
@@ -16,7 +16,7 @@
         [Fact]
         public void InitializeThrowIfHttpContextAccessorIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => { var initializer = new OperationNameTelemetryInitializer(null); });
+            Assert.Throws<ArgumentNullException>(() => { var initializer = new OperationNameTelemetryInitializer(null, null); });
         }
 
         [Fact]
@@ -24,7 +24,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
 
-            var initializer = new OperationNameTelemetryInitializer(ac);
+            var initializer = new OperationNameTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -34,7 +34,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
 
-            var initializer = new OperationNameTelemetryInitializer(ac);
+            var initializer = new OperationNameTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -44,7 +44,7 @@
         {
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), null);
 
-            var initializer = new OperationNameTelemetryInitializer(contextAccessor);
+            var initializer = new OperationNameTelemetryInitializer(contextAccessor, null);
 
             var telemetry = new EventTelemetry();
             telemetry.Context.Operation.Name = "Name";
@@ -58,7 +58,7 @@
         {
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), null);
 
-            var initializer = new OperationNameTelemetryInitializer(contextAccessor);
+            var initializer = new OperationNameTelemetryInitializer(contextAccessor, null);
 
             var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry);
@@ -72,7 +72,7 @@
             var telemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(telemetry, null);
 
-            var initializer = new OperationNameTelemetryInitializer(contextAccessor);
+            var initializer = new OperationNameTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(telemetry);
 
@@ -88,7 +88,7 @@
 
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
 
-            var initializer = new OperationNameTelemetryInitializer(contextAccessor);
+            var initializer = new OperationNameTelemetryInitializer(contextAccessor, null);
 
             var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry);
@@ -106,7 +106,7 @@
 
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
 
-            var initializer = new OperationNameTelemetryInitializer(contextAccessor);
+            var initializer = new OperationNameTelemetryInitializer(contextAccessor, null);
 
             var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry);
@@ -125,7 +125,7 @@
 
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
 
-            var initializer = new OperationNameTelemetryInitializer(contextAccessor);
+            var initializer = new OperationNameTelemetryInitializer(contextAccessor, null);
 
             var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry);
@@ -146,7 +146,7 @@
 
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
 
-            var initializer = new OperationNameTelemetryInitializer(contextAccessor);
+            var initializer = new OperationNameTelemetryInitializer(contextAccessor, null);
 
             var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry);
@@ -165,7 +165,7 @@
             
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
 
-            var initializer = new OperationNameTelemetryInitializer(contextAccessor);
+            var initializer = new OperationNameTelemetryInitializer(contextAccessor, null);
 
             var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry);
@@ -181,7 +181,7 @@
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(telemetry);
             contextAccessor.HttpContext.Request.Method = "POST";
 
-            var initializer = new OperationNameTelemetryInitializer(contextAccessor);
+            var initializer = new OperationNameTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(telemetry);
 

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/TelemetryInitializerBaseTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/TelemetryInitializerBaseTest.cs
@@ -1,0 +1,69 @@
+﻿namespace Microsoft.ApplicationInsights.AspNet.Tests.TelemetryInitializers
+{
+    using System;
+    using System.Diagnostics.Tracing;
+    using Microsoft.ApplicationInsights.AspNet.TelemetryInitializers;
+    using Microsoft.ApplicationInsights.AspNet.Tests.Helpers;
+    using Microsoft.ApplicationInsights.AspNet.Tracing;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.AspNet.Hosting;
+    using Microsoft.AspNet.Http;
+    using Microsoft.AspNet.Http.Core;
+    using Xunit;
+
+    public class TelemetryInitializerBaseTest
+    {
+        private class TelemetryInitializerMock : TelemetryInitializerBase
+        {
+            public TelemetryInitializerMock(IHttpContextAccessor httpContextAccessor, AspNet5EventSource eventSource)
+                : base(httpContextAccessor, eventSource)
+            {
+
+            }
+
+            protected override void OnInitializeTelemetry(HttpContext platformContext, RequestTelemetry requestTelemetry, ITelemetry telemetry)
+            {
+                //do nothing
+            }
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowAndTracesVerboseMessageIfHttpContextIsUnavailable()
+        {
+            var ac = new HttpContextAccessor() { HttpContext = null };
+
+            var eventSource = new Tracing.AspNet5EventSource();
+
+            using (var eventListener = new AspNet5EventTestListener(eventSource))
+            {
+                var initializer = new TelemetryInitializerMock(ac, eventSource);
+
+                initializer.Initialize(new RequestTelemetry());
+
+                Assert.Equal(1, eventListener.Events.Count);
+                Assert.Contains("HttpContext is null", eventListener.Events[0].Message);
+                Assert.Equal(EventLevel.Verbose, eventListener.Events[0].Level);
+            }
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowAndTracesVerboseMessageIfRequestTelemetryIsUnavailable()
+        {
+            var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
+
+            var eventSource = new Tracing.AspNet5EventSource();
+
+            using (var eventListener = new AspNet5EventTestListener(eventSource))
+            {
+                var initializer = new TelemetryInitializerMock(ac, eventSource);
+
+                initializer.Initialize(new RequestTelemetry());
+
+                Assert.Equal(1, eventListener.Events.Count);
+                Assert.Contains("RequestServices are not available", eventListener.Events[0].Message);
+                Assert.Equal(EventLevel.Verbose, eventListener.Events[0].Level);
+            }
+        }
+    }
+}

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/UserAgentTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/UserAgentTelemetryInitializerTests.cs
@@ -15,7 +15,7 @@
         [Fact]
         public void InitializeThrowIfHttpContextAccessorIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => { var initializer = new UserAgentTelemetryInitializer(null); });
+            Assert.Throws<ArgumentNullException>(() => { var initializer = new UserAgentTelemetryInitializer(null, null); });
         }
 
         [Fact]
@@ -23,7 +23,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
 
-            var initializer = new UserAgentTelemetryInitializer(ac);
+            var initializer = new UserAgentTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -33,7 +33,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
 
-            var initializer = new UserAgentTelemetryInitializer(ac);
+            var initializer = new UserAgentTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -44,7 +44,7 @@
             var requestTelemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers.Add("User-Agent", new[] { "test" });
-            var initializer = new UserAgentTelemetryInitializer(contextAccessor);
+            var initializer = new UserAgentTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(requestTelemetry);
 
@@ -58,7 +58,7 @@
             requestTelemetry.Context.User.UserAgent = "Inline";
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers.Add("User-Agent", new[] { "test" });
-            var initializer = new UserAgentTelemetryInitializer(contextAccessor);
+            var initializer = new UserAgentTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(requestTelemetry);
 

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/UserAgentTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/UserAgentTelemetryInitializerTests.cs
@@ -23,7 +23,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
 
-            var initializer = new UserAgentTelemetryInitializer(ac, null);
+            var initializer = new UserAgentTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -33,7 +33,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
 
-            var initializer = new UserAgentTelemetryInitializer(ac, null);
+            var initializer = new UserAgentTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/WebSessionTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/WebSessionTelemetryInitializerTests.cs
@@ -14,7 +14,7 @@
         [Fact]
         public void InitializeThrowIfHttpContextAccessorIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => { var initializer = new WebSessionTelemetryInitializer(null); });
+            Assert.Throws<ArgumentNullException>(() => { var initializer = new WebSessionTelemetryInitializer(null, null); });
         }
 
         [Fact]
@@ -22,7 +22,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
 
-            var initializer = new WebSessionTelemetryInitializer(ac);
+            var initializer = new WebSessionTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -32,7 +32,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
 
-            var initializer = new WebSessionTelemetryInitializer(ac);
+            var initializer = new WebSessionTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -43,7 +43,7 @@
             var requestTelemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers["Cookie"] = "ai_session=test|2015-04-10T17:11:38.378Z|2015-04-10T17:11:39.180Z";
-            var initializer = new WebSessionTelemetryInitializer(contextAccessor);
+            var initializer = new WebSessionTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(requestTelemetry);
 
@@ -57,7 +57,7 @@
             requestTelemetry.Context.Session.Id = "Inline";
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers["Cookie"] = "ai_session=test|2015-04-10T17:11:38.378Z|2015-04-10T17:11:39.180Z";
-            var initializer = new WebSessionTelemetryInitializer(contextAccessor);
+            var initializer = new WebSessionTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(requestTelemetry);
 

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/WebSessionTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/WebSessionTelemetryInitializerTests.cs
@@ -22,7 +22,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
 
-            var initializer = new WebSessionTelemetryInitializer(ac, null);
+            var initializer = new WebSessionTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -32,7 +32,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
 
-            var initializer = new WebSessionTelemetryInitializer(ac, null);
+            var initializer = new WebSessionTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -43,7 +43,7 @@
             var requestTelemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers["Cookie"] = "ai_session=test|2015-04-10T17:11:38.378Z|2015-04-10T17:11:39.180Z";
-            var initializer = new WebSessionTelemetryInitializer(contextAccessor, null);
+            var initializer = new WebSessionTelemetryInitializer(contextAccessor, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(requestTelemetry);
 

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/WebUserTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/WebUserTelemetryInitializerTests.cs
@@ -14,7 +14,7 @@
         [Fact]
         public void InitializeThrowIfHttpContextAccessorIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => { var initializer = new WebUserTelemetryInitializer(null); });
+            Assert.Throws<ArgumentNullException>(() => { var initializer = new WebUserTelemetryInitializer(null, null); });
         }
 
         [Fact]
@@ -22,7 +22,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
 
-            var initializer = new WebUserTelemetryInitializer(ac);
+            var initializer = new WebUserTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -32,7 +32,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
 
-            var initializer = new WebUserTelemetryInitializer(ac);
+            var initializer = new WebUserTelemetryInitializer(ac, null);
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -43,7 +43,7 @@
             var requestTelemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers["Cookie"] = "ai_user=test|2015-04-09T21:51:59.993Z";
-            var initializer = new WebUserTelemetryInitializer(contextAccessor);
+            var initializer = new WebUserTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(requestTelemetry);
 
@@ -58,7 +58,7 @@
             requestTelemetry.Context.User.Id = "Inline";
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers["Cookie"] = "ai_user=test|2015-04-09T21:51:59.993Z";
-            var initializer = new WebUserTelemetryInitializer(contextAccessor);
+            var initializer = new WebUserTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(requestTelemetry);
 
@@ -71,7 +71,7 @@
             var requestTelemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers["Cookie"] = "ai_user=test";
-            var initializer = new WebUserTelemetryInitializer(contextAccessor);
+            var initializer = new WebUserTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(requestTelemetry);
 
@@ -84,7 +84,7 @@
             var requestTelemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers["Cookie"] = "ai_user=test|malformeddate";
-            var initializer = new WebUserTelemetryInitializer(contextAccessor);
+            var initializer = new WebUserTelemetryInitializer(contextAccessor, null);
 
             initializer.Initialize(requestTelemetry);
             Assert.Equal(null, requestTelemetry.Context.User.Id);

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/WebUserTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/WebUserTelemetryInitializerTests.cs
@@ -22,7 +22,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = null };
 
-            var initializer = new WebUserTelemetryInitializer(ac, null);
+            var initializer = new WebUserTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -32,7 +32,7 @@
         {
             var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
 
-            var initializer = new WebUserTelemetryInitializer(ac, null);
+            var initializer = new WebUserTelemetryInitializer(ac, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(new RequestTelemetry());
         }
@@ -71,7 +71,7 @@
             var requestTelemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers["Cookie"] = "ai_user=test";
-            var initializer = new WebUserTelemetryInitializer(contextAccessor, null);
+            var initializer = new WebUserTelemetryInitializer(contextAccessor, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(requestTelemetry);
 
@@ -84,7 +84,7 @@
             var requestTelemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
             contextAccessor.HttpContext.Request.Headers["Cookie"] = "ai_user=test|malformeddate";
-            var initializer = new WebUserTelemetryInitializer(contextAccessor, null);
+            var initializer = new WebUserTelemetryInitializer(contextAccessor, new Tracing.AspNet5EventSource());
 
             initializer.Initialize(requestTelemetry);
             Assert.Equal(null, requestTelemetry.Context.User.Id);

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/project.json
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/project.json
@@ -1,13 +1,14 @@
 {
     "dependencies": {
+        "FunctionalTestUtils": "1.0.0-*",   
         "Microsoft.ApplicationInsights.AspNet": "0.32.0-beta4",        
         "Microsoft.AspNet.FeatureModel": "1.0.0-beta4-*",
         "Microsoft.AspNet.Http": "1.0.0-beta4-*",
         "Microsoft.AspNet.Http.Extensions": "1.0.0-beta4-*",
         "Microsoft.AspNet.Hosting": "1.0.0-beta4-*",
         "Microsoft.AspNet.Mvc.Core": "6.0.0-beta4-*",
-        "Microsoft.Framework.Logging": "1.0.0-beta4-*",        
-        "Microsoft.Framework.ConfigurationModel.Json": "1.0.0-beta4-*",        
+        "Microsoft.Framework.Logging": "1.0.0-beta4-*",
+        "Microsoft.Framework.ConfigurationModel.Json": "1.0.0-beta4-*",
         "xunit": "2.1.0-beta2-*",
         "xunit.runner.dnx": "2.1.0-beta2-*"
     },

--- a/test/Mvc6Framework45.FunctionalTests/FunctionalTest/ExceptionTelemetryTests.cs
+++ b/test/Mvc6Framework45.FunctionalTests/FunctionalTest/ExceptionTelemetryTests.cs
@@ -9,10 +9,8 @@
 
     public class ExceptionTelemetryTests : TelemetryTestsBase
     {
-        private ITestOutputHelper output;
-        public ExceptionTelemetryTests(ITestOutputHelper output)
+        public ExceptionTelemetryTests()
         {
-            this.output = output;
         }
 
         private const string assemblyName = "Mvc6Framework45.FunctionalTests";
@@ -20,21 +18,17 @@
         [Fact]
         public void TestBasicRequestPropertiesAfterRequestingControllerThatThrows()
         {
-            using (var eventListener = new Aspnet5EventTestListener(output))
+            using (var server = new InProcessServer(assemblyName))
             {
-                using (var server = new InProcessServer(assemblyName))
-                {
-                    const string RequestPath = "/Home/Exception";
+                const string RequestPath = "/Home/Exception";
 
-                    var expectedRequestTelemetry = new RequestTelemetry();
-                    expectedRequestTelemetry.HttpMethod = "GET";
-                    expectedRequestTelemetry.Name = "GET Home/Exception";
-                    expectedRequestTelemetry.ResponseCode = "500";
-                    expectedRequestTelemetry.Success = false;
-                    expectedRequestTelemetry.Url = new System.Uri(server.BaseHost + RequestPath);
-                    this.ValidateBasicRequest(server, "/Home/Exception", expectedRequestTelemetry);
-                }
-                Assert.False(eventListener.HasIssues, eventListener.Issues);
+                var expectedRequestTelemetry = new RequestTelemetry();
+                expectedRequestTelemetry.HttpMethod = "GET";
+                expectedRequestTelemetry.Name = "GET Home/Exception";
+                expectedRequestTelemetry.ResponseCode = "500";
+                expectedRequestTelemetry.Success = false;
+                expectedRequestTelemetry.Url = new System.Uri(server.BaseHost + RequestPath);
+                this.ValidateBasicRequest(server, "/Home/Exception", expectedRequestTelemetry);
             }
         }
 

--- a/test/Mvc6Framework45.FunctionalTests/FunctionalTest/ExceptionTelemetryTests.cs
+++ b/test/Mvc6Framework45.FunctionalTests/FunctionalTest/ExceptionTelemetryTests.cs
@@ -4,25 +4,37 @@
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
+    using Microsoft.ApplicationInsights.AspNet.Tests.Helpers;
+    using Xunit.Abstractions;
 
     public class ExceptionTelemetryTests : TelemetryTestsBase
     {
+        private ITestOutputHelper output;
+        public ExceptionTelemetryTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
         private const string assemblyName = "Mvc6Framework45.FunctionalTests";
 
         [Fact]
         public void TestBasicRequestPropertiesAfterRequestingControllerThatThrows()
         {
-            using (var server = new InProcessServer(assemblyName))
+            using (var eventListener = new Aspnet5EventTestListener(output))
             {
-                const string RequestPath = "/Home/Exception";
+                using (var server = new InProcessServer(assemblyName))
+                {
+                    const string RequestPath = "/Home/Exception";
 
-                var expectedRequestTelemetry = new RequestTelemetry();
-                expectedRequestTelemetry.HttpMethod = "GET";
-                expectedRequestTelemetry.Name = "GET Home/Exception";
-                expectedRequestTelemetry.ResponseCode = "500";
-                expectedRequestTelemetry.Success = false;
-                expectedRequestTelemetry.Url = new System.Uri(server.BaseHost + RequestPath);
-                this.ValidateBasicRequest(server, "/Home/Exception", expectedRequestTelemetry);
+                    var expectedRequestTelemetry = new RequestTelemetry();
+                    expectedRequestTelemetry.HttpMethod = "GET";
+                    expectedRequestTelemetry.Name = "GET Home/Exception";
+                    expectedRequestTelemetry.ResponseCode = "500";
+                    expectedRequestTelemetry.Success = false;
+                    expectedRequestTelemetry.Url = new System.Uri(server.BaseHost + RequestPath);
+                    this.ValidateBasicRequest(server, "/Home/Exception", expectedRequestTelemetry);
+                }
+                Assert.False(eventListener.HasIssues, eventListener.Issues);
             }
         }
 


### PR DESCRIPTION
Use EventSource via Dependency Injection. One example of how to read event source messages. However this example is not working as TestExplorer doesn't support test output today. 


@upendras  - who was a contact in Visual Studio to ask when they'll support test output in Test Explorer?