### PR TITLE
Adding server telemetry channel, adaptive sampling and making Active as default configuraiton.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 ﻿{
     "sources": [ "src", "test" ],
     "sdk": {
-            "architecture": "x86",
+      "architecture": "x86",
       "runtime": "clr",
-      "version": "1.0.0-rc1-update1"
+      "version": "1.0.0-rc1-update2"
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
@@ -40,7 +40,7 @@
             return app.UseMiddleware<ExceptionTrackingMiddleware>();
         }
 
-        public static void AddApplicationInsightsTelemetry(this IServiceCollection services, IConfiguration config, bool DisableSampling = false)
+        public static void AddApplicationInsightsTelemetry(this IServiceCollection services, IConfiguration config, bool disableSampling = false)
         {
             services.AddSingleton<ITelemetryInitializer, DomainNameRoleInstanceTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer>(serviceProvider =>
@@ -64,7 +64,7 @@
             services.AddSingleton<TelemetryConfiguration>(serviceProvider =>
             {
                 var telemetryConfiguration = TelemetryConfiguration.Active;
-                AddServerTelemetryChannelAndSamplingForFullFramework(serviceProvider, telemetryConfiguration, DisableSampling);
+                AddServerTelemetryChannelAndSamplingForFullFramework(serviceProvider, telemetryConfiguration, disableSampling);
                 telemetryConfiguration.TelemetryChannel = serviceProvider.GetService<ITelemetryChannel>() ?? telemetryConfiguration.TelemetryChannel;
                 AddTelemetryConfiguration(config, telemetryConfiguration);
                 AddServicesToCollection(serviceProvider, telemetryConfiguration.TelemetryInitializers);
@@ -185,14 +185,14 @@
             }
         }
 
-        private static void AddServerTelemetryChannelAndSamplingForFullFramework(IServiceProvider serviceProvider, TelemetryConfiguration configuration, bool DisableSampling)
+        private static void AddServerTelemetryChannelAndSamplingForFullFramework(IServiceProvider serviceProvider, TelemetryConfiguration configuration, bool disableSampling)
         {
 #if dnx451
             configuration.TelemetryChannel = serviceProvider.GetService<ITelemetryChannel>() ??  new ServerTelemetryChannel();
 
             if (configuration.TelemetryChannel.GetType() == typeof(ServerTelemetryChannel))
             {
-                if (!DisableSampling)
+                if (!disableSampling)
                 {
                     configuration.TelemetryProcessorChainBuilder.UseAdaptiveSampling();
                     configuration.TelemetryProcessorChainBuilder.Build();

--- a/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/Extensions/ApplicationInsightsExtensions.cs
@@ -40,7 +40,7 @@
             return app.UseMiddleware<ExceptionTrackingMiddleware>();
         }
 
-        public static void AddApplicationInsightsTelemetry(this IServiceCollection services, IConfiguration config, bool disableSampling = false)
+        public static void AddApplicationInsightsTelemetry(this IServiceCollection services, IConfiguration config, bool disableDefaultAdaptiveSampling = false)
         {
             services.AddSingleton<ITelemetryInitializer, DomainNameRoleInstanceTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer>(serviceProvider =>
@@ -64,7 +64,7 @@
             services.AddSingleton<TelemetryConfiguration>(serviceProvider =>
             {
                 var telemetryConfiguration = TelemetryConfiguration.Active;
-                AddServerTelemetryChannelAndSamplingForFullFramework(serviceProvider, telemetryConfiguration, disableSampling);
+                AddServerTelemetryChannelAndSamplingForFullFramework(serviceProvider, telemetryConfiguration, disableDefaultAdaptiveSampling);
                 telemetryConfiguration.TelemetryChannel = serviceProvider.GetService<ITelemetryChannel>() ?? telemetryConfiguration.TelemetryChannel;
                 AddTelemetryConfiguration(config, telemetryConfiguration);
                 AddServicesToCollection(serviceProvider, telemetryConfiguration.TelemetryInitializers);

--- a/src/Microsoft.ApplicationInsights.AspNet/project.json
+++ b/src/Microsoft.ApplicationInsights.AspNet/project.json
@@ -14,7 +14,7 @@
         "delaySign": true
     },
     "dependencies": {
-        "Microsoft.ApplicationInsights": "2.0.0-*",
+        "Microsoft.ApplicationInsights": "2.0.0",
         "Microsoft.AspNet.Hosting.Abstractions": "1.0.0-rc1-final",
         "Microsoft.AspNet.Http.Abstractions": "1.0.0-rc1-final",
         "Microsoft.AspNet.Http.Features": "1.0.0-rc1-final",
@@ -30,8 +30,9 @@
           "define": [ "dnx451" ]
         },
         "dependencies": {
-          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.0.0-*",
-          "Microsoft.ApplicationInsights.DependencyCollector": "2.0.0-*"
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.0.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.0.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.0.0"
         }
       },
         "dnxcore50": {

--- a/test/EmptyApp.FunctionalTests/Startup.cs
+++ b/test/EmptyApp.FunctionalTests/Startup.cs
@@ -24,7 +24,7 @@ namespace EmptyApp.FunctionalTests
 
             var builder = new ConfigurationBuilder();
             builder.AddApplicationInsightsSettings(instrumentationKey: "Foo");
-            services.AddApplicationInsightsTelemetry(builder.Build(), false);
+            services.AddApplicationInsightsTelemetry(builder.Build());
         }
 
         public void Configure(IApplicationBuilder app)

--- a/test/EmptyApp.FunctionalTests/project.json
+++ b/test/EmptyApp.FunctionalTests/project.json
@@ -1,14 +1,13 @@
 ﻿{
   "webroot": "wwwroot",
-  "version": "1.0.0-*",
   "compilationOptions": {
     "keyFile": "../../keys/35MSSharedLib1024.snk",
     "delaySign": true
     },
   "dependencies": {
     "Microsoft.AspNet.Server.WebListener": "1.0.0-rc1-final",
-    "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-final",
-    "FunctionalTestUtils": "1.0.0-rc1-final",
+    "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-update3",
+    "FunctionalTestUtils": "1.0.0-rc1",
     "xunit.runner.dnx": "2.1.0-rc1-*",
     "xunit": "2.1.0-rc1-*",
     "Microsoft.AspNet.Diagnostics": "1.0.0-rc1-final"

--- a/test/EmptyApp.FunctionalTests/project.json
+++ b/test/EmptyApp.FunctionalTests/project.json
@@ -9,7 +9,7 @@
     "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-update3",
     "FunctionalTestUtils": "1.0.0-rc1",
     "xunit.runner.dnx": "2.1.0-rc1-*",
-    "xunit": "2.1.0-rc1-*",
+    "xunit": "2.1.0",
     "Microsoft.AspNet.Diagnostics": "1.0.0-rc1-final"
   },
 

--- a/test/FunctionalTestUtils/project.json
+++ b/test/FunctionalTestUtils/project.json
@@ -11,7 +11,7 @@
     "Microsoft.AspNet.Server.WebListener": "1.0.0-rc1-final",
     "Microsoft.Dnx.Runtime": "1.0.0-rc1-final",
     "xunit.runner.dnx": "2.1.0-rc1-*",
-    "xunit": "2.1.0-rc-*",
+    "xunit": "2.1.0",
     "System.Net.Http": "4.0.0-beta-*"
   },
 

--- a/test/FunctionalTestUtils/project.json
+++ b/test/FunctionalTestUtils/project.json
@@ -1,12 +1,12 @@
 ﻿{
-    "version": "1.0.0-rc1-*",
+    "version": "1.0.0-rc1",
     "compilationOptions": {
         "keyFile": "../../keys/35MSSharedLib1024.snk",
         "delaySign": true
     },
   "dependencies": {
     "Microsoft.ApplicationInsights": "2.0.0-*",
-    "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-final",
+    "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-update3",
     "Microsoft.AspNet.Http.Abstractions": "1.0.0-rc1-final",
     "Microsoft.AspNet.Server.WebListener": "1.0.0-rc1-final",
     "Microsoft.Dnx.Runtime": "1.0.0-rc1-final",

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Extensions.DependencyInjection
+﻿using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+namespace Microsoft.Extensions.DependencyInjection.Tests
 {
     using System;
     using System.Diagnostics;
@@ -17,6 +20,7 @@
 #if dnx451
     using ApplicationInsights.DependencyCollector;
     using ApplicationInsights.Extensibility.PerfCounterCollector;
+    using ApplicationInsights.WindowsServer.TelemetryChannel;
 #endif
 
     public static class ApplicationInsightsExtensionsTests
@@ -50,7 +54,7 @@
             {
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
 
-                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build(), false);
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
 
                 ServiceDescriptor service = services.Single(s => s.ServiceType == serviceType && s.ImplementationType == implementationType);
                 Assert.Equal(lifecycle, service.Lifetime);
@@ -64,7 +68,7 @@
                 //Empty configuration that doesn't have instrumentation key
                 IConfiguration config = new ConfigurationBuilder().Build();
 
-                services.AddApplicationInsightsTelemetry(config, false);
+                services.AddApplicationInsightsTelemetry(config);
             }
 
             [Fact]
@@ -72,7 +76,7 @@
             {
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
 
-                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build(), false);
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -88,31 +92,11 @@
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
                 var config = new ConfigurationBuilder().AddJsonFile("content\\config-instrumentation-key.json").Build();
 
-                services.AddApplicationInsightsTelemetry(config, false);
+                services.AddApplicationInsightsTelemetry(config);
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
                 Assert.Equal(TestInstrumentationKey, telemetryConfiguration.InstrumentationKey);
-            }
-
-            /// <summary>
-            /// Tests that the Active configuration singleton is not updated by the configuration factory when specifying false for re-using
-            /// the Active config singleton when registering Application Insights services for dependency injection.
-            /// </summary>
-            [Fact]
-            public static void ConfigurationFactoryMethodDoesNotUpdateTheActiveConfigurationSingletonWhenSetToFalse()
-            {
-                string existingActiveIkey = TelemetryConfiguration.Active.InstrumentationKey;
-
-                ServiceCollection services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
-                IConfiguration config = new ConfigurationBuilder().AddJsonFile("content\\config-instrumentation-key-new.json").Build();
-
-                Assert.NotEqual(existingActiveIkey, config.GetSection(InstrumentationKeyFromConfig).Value);
-                services.AddApplicationInsightsTelemetry(config, false);
-
-                IServiceProvider serviceProvider = services.BuildServiceProvider();
-                TelemetryConfiguration telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
-                Assert.Equal(existingActiveIkey, TelemetryConfiguration.Active.InstrumentationKey);
             }
 
             /// <summary>
@@ -139,7 +123,7 @@
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
                 var config = new ConfigurationBuilder().AddJsonFile("content\\config-developer-mode.json").Build();
 
-                services.AddApplicationInsightsTelemetry(config, false);
+                services.AddApplicationInsightsTelemetry(config);
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -152,7 +136,7 @@
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
                 var config = new ConfigurationBuilder().AddJsonFile("content\\config-endpoint-address.json").Build();
 
-                services.AddApplicationInsightsTelemetry(config, false);
+                services.AddApplicationInsightsTelemetry(config);
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -168,7 +152,7 @@
                 var config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
                 try
                 {
-                    services.AddApplicationInsightsTelemetry(config, false);
+                    services.AddApplicationInsightsTelemetry(config);
 
                     IServiceProvider serviceProvider = services.BuildServiceProvider();
                     var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -188,7 +172,7 @@
                 var config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
                 try
                 {
-                    services.AddApplicationInsightsTelemetry(config, false);
+                    services.AddApplicationInsightsTelemetry(config);
 
                     IServiceProvider serviceProvider = services.BuildServiceProvider();
                     var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -208,7 +192,7 @@
                 var config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
                 try
                 {
-                    services.AddApplicationInsightsTelemetry(config, false);
+                    services.AddApplicationInsightsTelemetry(config);
 
                     IServiceProvider serviceProvider = services.BuildServiceProvider();
                     var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -227,7 +211,7 @@
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
                 services.AddInstance<ITelemetryInitializer>(telemetryInitializer);
 
-                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build(), false);
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -241,7 +225,7 @@
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
                 services.AddInstance<ITelemetryChannel>(telemetryChannel);
 
-                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build(), false);
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -253,7 +237,7 @@
             {
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
 
-                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build(), false);
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -268,7 +252,7 @@
 
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
 
-                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build(), false);
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var configuration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -289,7 +273,7 @@
             {
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
 
-                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build(), false);
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
@@ -302,6 +286,45 @@
                 var perfCounterModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(PerformanceCollectorModule));
                 Assert.NotNull(perfCounterModule);
             }
+
+            [Fact]
+            public static void AddsAddaptiveSamplingServiceToTheConfigurationInFullFrameworkByDefault()
+            {
+                var exisitingProcessorCount = TelemetryConfiguration.Active.TelemetryProcessors.Count;
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                var config = new ConfigurationBuilder().AddApplicationInsightsSettings(endpointAddress: "http://localhost:1234/v2/track/").Build();
+                services.AddApplicationInsightsTelemetry(config);
+
+                IServiceProvider serviceProvider = services.BuildServiceProvider();
+                var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
+                Assert.True(telemetryConfiguration.TelemetryProcessors.Count >= exisitingProcessorCount);
+                Assert.True(telemetryConfiguration.TelemetryProcessors.Any<ITelemetryProcessor>(processor => processor.GetType() == typeof(AdaptiveSamplingTelemetryProcessor)));
+            }
+
+            [Fact]
+            public static void AddsServerTelemetryChannelInFullFramework()
+            {
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                var config = new ConfigurationBuilder().AddApplicationInsightsSettings(endpointAddress: "http://localhost:1234/v2/track/").Build();
+                services.AddApplicationInsightsTelemetry(config);
+
+                IServiceProvider serviceProvider = services.BuildServiceProvider();
+                var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
+                Assert.Equal(telemetryConfiguration.TelemetryChannel.GetType(), typeof(ServerTelemetryChannel));
+            }
+
+            [Fact]
+            public static void DoesNotOverWriteExistingChannelInFullFramework()
+            {
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                services.AddSingleton<ITelemetryChannel, InMemoryChannel>();
+                var config = new ConfigurationBuilder().AddApplicationInsightsSettings(endpointAddress: "http://localhost:1234/v2/track/").Build();
+                services.AddApplicationInsightsTelemetry(config);
+
+                IServiceProvider serviceProvider = services.BuildServiceProvider();
+                var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
+                Assert.Equal(telemetryConfiguration.TelemetryChannel.GetType(), typeof(InMemoryChannel));
+            }
 #endif
         }
 
@@ -313,7 +336,7 @@
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
 
                 var config = new ConfigurationBuilder().AddApplicationInsightsSettings(instrumentationKey: TestInstrumentationKey).Build();
-                services.AddApplicationInsightsTelemetry(config, false);
+                services.AddApplicationInsightsTelemetry(config);
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -325,7 +348,7 @@
             {
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
                 var config = new ConfigurationBuilder().AddApplicationInsightsSettings(developerMode: true).Build();
-                services.AddApplicationInsightsTelemetry(config, false);
+                services.AddApplicationInsightsTelemetry(config);
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
@@ -337,7 +360,7 @@
             {
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
                 var config = new ConfigurationBuilder().AddApplicationInsightsSettings(endpointAddress: "http://localhost:1234/v2/track/").Build();
-                services.AddApplicationInsightsTelemetry(config, false);
+                services.AddApplicationInsightsTelemetry(config);
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetRequiredService<TelemetryConfiguration>();

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/project.json
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/project.json
@@ -4,7 +4,7 @@
     "delaySign": true
     },
   "dependencies": {
-    "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-final",
+    "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-update3",
     "Microsoft.AspNet.Http.Features": "1.0.0-rc1-final",
     "Microsoft.AspNet.Http": "1.0.0-rc1-final",
     "Microsoft.AspNet.Http.Extensions": "1.0.0-rc1-final",

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/project.json
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/project.json
@@ -13,7 +13,7 @@
     "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-rc1-final",
     "xunit.runner.dnx": "2.1.0-rc1-*",
-    "xunit": "2.1.0-rc1-*"
+    "xunit": "2.1.0"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/Mvc6Framework45.FunctionalTests/Startup.cs
+++ b/test/Mvc6Framework45.FunctionalTests/Startup.cs
@@ -45,7 +45,7 @@ namespace Mvc6Framework45.FunctionalTests
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddInstance<ITelemetryChannel>(new BackTelemetryChannel());
-            services.AddApplicationInsightsTelemetry(Configuration, false);
+            services.AddApplicationInsightsTelemetry(Configuration);
 
             // Add Application settings to the services container.
             services.Configure<AppSettings>(Configuration.GetSection("AppSettings"));

--- a/test/Mvc6Framework45.FunctionalTests/project.json
+++ b/test/Mvc6Framework45.FunctionalTests/project.json
@@ -1,12 +1,11 @@
 {
   "webroot": "wwwroot",
   "userSecretsId": "aspnet5-Mvc6Framework45.FunctionalTests-42f45116-363a-40d3-9c44-bc58885d6e96",
-  "version": "1.0.0-rc1-*",
   "dependencies": {
     "EntityFramework.MicrosoftSqlServer": "7.0.0-rc1-final",
     "EntityFramework.Commands": "7.0.0-rc1-final",
-    "FunctionalTestUtils": "1.0.0-rc1-final",
-    "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-final",
+    "FunctionalTestUtils": "1.0.0-rc1",
+    "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-update3",
     "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
     "Microsoft.AspNet.Mvc.TagHelpers": "6.0.0-rc1-final",
     "Microsoft.AspNet.Authentication.Cookies": "1.0.0-rc1-final",

--- a/test/Mvc6Framework45.FunctionalTests/project.json
+++ b/test/Mvc6Framework45.FunctionalTests/project.json
@@ -25,7 +25,7 @@
     "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
     "xunit.runner.dnx": "2.1.0-rc1-*",
-    "xunit": "2.1.0-rc1-*"
+    "xunit": "2.1.0"
   },
 
   "commands": {

--- a/test/WebApiShimFw46.FunctionalTests/Startup.cs
+++ b/test/WebApiShimFw46.FunctionalTests/Startup.cs
@@ -29,7 +29,7 @@ namespace SampleWebAPIIntegration
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddInstance<ITelemetryChannel>(new BackTelemetryChannel());
-            services.AddApplicationInsightsTelemetry(Configuration, false);
+            services.AddApplicationInsightsTelemetry(Configuration);
 
             // Uncomment the following line to add Web API services which makes it easier to port Web API 2 controllers.
             // You will also need to add the Microsoft.AspNet.Mvc.WebApiCompatShim package to the 'dependencies' section of project.json.

--- a/test/WebApiShimFw46.FunctionalTests/project.json
+++ b/test/WebApiShimFw46.FunctionalTests/project.json
@@ -1,13 +1,12 @@
 {
     "webroot": "wwwroot",
-    "version": "1.0.0-beta8-*",
     "compilationOptions": {
         "keyFile": "../../keys/35MSSharedLib1024.snk",
         "delaySign": true
     },
   "dependencies": {
-    "FunctionalTestUtils": "1.0.0-rc1-final",
-    "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-final",
+    "FunctionalTestUtils": "1.0.0-rc1",
+    "Microsoft.ApplicationInsights.AspNet": "1.0.0-rc1-update3",
     "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
     "Microsoft.AspNet.Mvc.WebApiCompatShim": "6.0.0-rc1-final",
     "Microsoft.AspNet.Server.WebListener": "1.0.0-rc1-final",

--- a/test/WebApiShimFw46.FunctionalTests/project.json
+++ b/test/WebApiShimFw46.FunctionalTests/project.json
@@ -14,7 +14,7 @@
     "Microsoft.AspNet.WebApi.Client": "5.2.0",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-rc1-final",
     "xunit.runner.dnx": "2.1.0-rc1-*",
-    "xunit": "2.1.0-rc1-*"
+    "xunit": "2.1.0"
   },
 
     "commands": {


### PR DESCRIPTION
Adding server telemetry channel, enabling sampling (with default adaptive) and removing existing configure option to create config.

- TelemetryConfiguration.Active is used if services do not have an existing configuration instance, in which case it picks the configuration from the services and updates it.
- Server telemetry channel is assigned to `config.TelemetryChannel` only in full framework, and if no other telemetry channel exists in services (in which case, `config.TelemetryChannel` will be the existing channel in services).
- Neither the channel nor the sampling processor is added to the services collection. 
- Customers have access to telemetry configuration, and can add his own custom telemetry processors through chain builder. 
- Customers can disable sampling using the parameter `DisableSampling` when adding Application Insights through services -> `services.AddApplicationInsightsTelemetry(config, true)`. This will not add `AdaptiveSamplingTelemetryProcessor` which is added by default in the other case.
- Existing boolean parameter on `services.AddApplicationInsightsTelemetry` to control the usage of `TelemetryConfiguration.Active` vs `TelemetryConfiguration.CreateDefault()` is removed and `Active` is used in all the scenarios.

**Note: By default, now, server telemetry channel will be used to send the telemetry, as opposed to InMemoryChannel. If customers have to use their specific channel, they can add channel to the services, and we pick that instead of our default channels.**