### PR TITLE
Tests fail in coreclr framework (in build), as TelemetryCOnfiguration…

### DIFF
--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
 
             [Fact]
             public static void RegistersTelemetryConfigurationFactoryMethodThatReadsEndpointAddressFromConfiguration()
-            {             
+            {
                 var services = CreateServicesAndAddApplicationinsightsTelemetry("content\\config-endpoint-address.json", null);
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
Tests fail in coreclr framework (in build), as TelemetryConfiguratin.Active is messed with fake telemetry channels. If the environment is coreclr, we just use the existing telemetry channel, thereby causing the tests to fail in the build. Adding a channel to services, will resolve as, AI picks the channel from services, if any such exists.