### PR TITLE
Enabling quickpulse metric stream by default along with the associated service option

### DIFF
--- a/RunTestsCore.ps1
+++ b/RunTestsCore.ps1
@@ -4,8 +4,7 @@ $VerbosePreference = "Continue";
 $TestProjects = @(
 	'.\test\Microsoft.ApplicationInsights.AspNetCore.Tests',
 	'.\test\MVCFramework45.FunctionalTests',
-	'.\test\WebApiShimFw46.FunctionalTests',
-    '.\test\EmptyApp.FunctionalTests'
+	'.\test\WebApiShimFw46.FunctionalTests'
 )
 
 Function Execute-DotnetProcess {
@@ -34,7 +33,7 @@ $global:WorkingDirectory = (pwd).Path;
 $dotnetPath = "C:\Program Files\dotnet\dotnet.exe";
 
 $TestProjects |% {
-	[String]$arguments = "test";
+	[String]$arguments = "test -f netcoreapp1.0";
 	[String]$currentWorkingDirectory = Join-Path $global:WorkingDirectory -ChildPath $_;
 	Write-Host "=========================================================";
 	Write-Host "== Executing tests";

--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ Function Execute-DotnetProcess {
     Write-Host "Process executed, ExitCode:$($p.ExitCode)";
 	Write-Host "Output:";
 	Write-Host $p.StandardOutput;
-	If ($p.ExitCode -ne 0) {
+	If (($Arguments -eq 'build') -and ($p.ExitCode -ne 0)) {
       $global:failed += $executeResult;
 	}
 }

--- a/build.ps1
+++ b/build.ps1
@@ -13,8 +13,8 @@ $Projects = @(
 
 $Commands = @(
     'restore',
-    'build',
-    'pack'
+    'build -c Release',
+    'pack -c Release'
 )
 
 Function Execute-DotnetProcess {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
@@ -5,39 +5,25 @@
     /// </summary>
     public class ApplicationInsightsServiceOptions
     {
-        private bool enableQuickPulseMetricStream = true;
-        private bool enableAdaptiveSampling = true;
+        /// <summary>
+        /// Application Insights service options that controlls the default behavior of application insights features.
+        /// </summary>
+        public ApplicationInsightsServiceOptions()
+        {
+            this.EnableQuickPulseMetricStream = true;
+            this.EnableAdaptiveSampling = true;
+        }
 
         /// <summary>
         /// Setting EnableQuickPulseMetricStream to false, will disable the default quick pulse metric stream. As a result, QuickPulseTelemetryModule
         /// and QuickPulseTelemetryProcessor are not registered with the configuration by default.
         /// </summary>
-        public bool EnableQuickPulseMetricStream
-        {
-            get
-            {
-                return enableQuickPulseMetricStream;
-            }
-            set
-            {
-                enableQuickPulseMetricStream = value;
-            }
-        }
+        public bool EnableQuickPulseMetricStream { get; set; }
 
         /// <summary>
         /// Setting EnableAdaptiveSampling to false, will disable the default adaptive sampling feature. As a result, no telemetry processor 
         /// that controls sampling is added to the service by default.
         /// </summary>
-        public bool EnableAdaptiveSampling
-        {
-            get
-            {
-                return enableAdaptiveSampling;
-            }
-            set
-            {
-                enableAdaptiveSampling = value;
-            }
-        }
+        public bool EnableAdaptiveSampling { get; set; }
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
@@ -5,7 +5,24 @@
     /// </summary>
     public class ApplicationInsightsServiceOptions
     {
+        private bool enableQuickPulseMetricStream = true;
         private bool enableAdaptiveSampling = true;
+
+        /// <summary>
+        /// Setting EnableQuickPulseMetricStream to false, will disable the default quick pulse metric stream. As a result, QuickPulseTelemetryModule
+        /// and QuickPulseTelemetryProcessor are not registered with the configuration by default.
+        /// </summary>
+        public bool EnableQuickPulseMetricStream
+        {
+            get
+            {
+                return enableQuickPulseMetricStream;
+            }
+            set
+            {
+                enableQuickPulseMetricStream = value;
+            }
+        }
 
         /// <summary>
         /// Setting EnableAdaptiveSampling to false, will disable the default adaptive sampling feature. As a result, no telemetry processor 

--- a/test/EmptyApp.FunctionalTests/project.json
+++ b/test/EmptyApp.FunctionalTests/project.json
@@ -24,7 +24,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002520"
+          "version": "1.0.0-*"
         }
       }
     },

--- a/test/FunctionalTestUtils/BackTelemetryChannel.cs
+++ b/test/FunctionalTestUtils/BackTelemetryChannel.cs
@@ -1,5 +1,4 @@
-﻿
-namespace FunctionalTestUtils
+﻿namespace FunctionalTestUtils
 {
     using System;
     using System.Collections.Generic;

--- a/test/FunctionalTestUtils/InProcessServer.cs
+++ b/test/FunctionalTestUtils/InProcessServer.cs
@@ -1,17 +1,11 @@
 ﻿namespace FunctionalTestUtils
 {
     using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
+    using System.IO;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Hosting.Server;
-    using Microsoft.AspNetCore.Http.Features;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.Configuration.Memory;
-    using Microsoft.Extensions.PlatformAbstractions;
-    using System.IO;
 
     // a variant of aspnet/Hosting/test/Microsoft.AspNet.Hosting.Tests/HostingEngineTests.cs
     public class InProcessServer : IDisposable

--- a/test/FunctionalTestUtils/TelemetryTestsBase.cs
+++ b/test/FunctionalTestUtils/TelemetryTestsBase.cs
@@ -14,7 +14,6 @@
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
     using Microsoft.ApplicationInsights.Extensibility;
 #endif
-    using Xunit;
 
     public abstract class TelemetryTestsBase
     {

--- a/test/FunctionalTestUtils/project.json
+++ b/test/FunctionalTestUtils/project.json
@@ -17,7 +17,7 @@
     "frameworks": {
       "net451": {
         "dependencies": {
-          "System.Net.Http": "4.0.1-rc2-*"
+          "System.Net.Http": "4.0.0"
         }
       },
       "netcoreapp1.0": {
@@ -29,7 +29,7 @@
         "dependencies": {
           "Microsoft.NETCore.App": {
             "type": "platform",
-            "version": "1.0.0-rc2-3002520"
+            "version": "1.0.0-*"
           }
         }
       }

--- a/test/MVCFramework45.FunctionalTests/MVCFramework45.FunctionalTests.xproj
+++ b/test/MVCFramework45.FunctionalTests/MVCFramework45.FunctionalTests.xproj
@@ -21,5 +21,8 @@
     <DnxInvisibleContent Include="package.json" />
     <DnxInvisibleContent Include=".npmrc" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/MVCFramework45.FunctionalTests/project.json
+++ b/test/MVCFramework45.FunctionalTests/project.json
@@ -55,7 +55,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002520"
+          "version": "1.0.0-*"
         }
       }
     },

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/ComponentVersionTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/ComponentVersionTelemetryInitializerTests.cs
@@ -1,45 +1,33 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNet.Tests.TelemetryInitializers
 {
+    using System;
     using Extensions.Configuration;
     using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Http.Internal;
-    using System.IO;
     using Xunit;
 
     public class ComponentVersionTelemetryInitializerTests
     {
+        private const string VersionKey = "version";
+
         [Fact]
         public void InitializeDoesNotThrowIfHttpContextIsUnavailable()
         {
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("project.json")
-                .Build();
-            var initializer = new ComponentVersionTelemetryInitializer(config);
+            var initializer = new ComponentVersionTelemetryInitializer(this.BuildConfigurationWithVersion());
             initializer.Initialize(new RequestTelemetry());
         }
 
         [Fact]
         public void InitializeDoesNotThrowIfRequestTelemetryIsUnavailable()
         {
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("project.json")
-                .Build();
-            var initializer = new ComponentVersionTelemetryInitializer(config);
+            var initializer = new ComponentVersionTelemetryInitializer(this.BuildConfigurationWithVersion());
             initializer.Initialize(new RequestTelemetry());
         }
 
         [Fact]
         public void InitializeAssignsVersionToTelemetry()
         {
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("project.json")
-                .Build();
-            var initializer = new ComponentVersionTelemetryInitializer(config);
+            var initializer = new ComponentVersionTelemetryInitializer(this.BuildConfigurationWithVersion());
             var telemetry = new RequestTelemetry();
             initializer.Initialize(telemetry);
             Assert.NotNull(telemetry.Context.Component.Version);
@@ -48,12 +36,8 @@
         [Fact]
         public void InitializeDoesNotOverrideExistingVersion()
         {
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("project.json")
-                .Build();
-            var initializer = new ComponentVersionTelemetryInitializer(config);
-
+            
+            var initializer = new ComponentVersionTelemetryInitializer(this.BuildConfigurationWithVersion());
             var telemetry = new RequestTelemetry();
             telemetry.Context.Component.Version = "TestVersion";
             initializer.Initialize(telemetry);
@@ -65,11 +49,18 @@
         public void InitializeDoesNotThrowIfVersionDoesNotExist()
         {
             var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
                 .Build();
             var initializer = new ComponentVersionTelemetryInitializer(config);
             var telemetry = new RequestTelemetry();
             initializer.Initialize(telemetry);
+        }
+
+        private IConfigurationRoot BuildConfigurationWithVersion()
+        {
+            Environment.SetEnvironmentVariable(VersionKey, "1.0.0");
+            return new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .Build();
         }
     }
 }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/project.json
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/project.json
@@ -32,7 +32,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002520"
+          "version": "1.0.0-*"
         }
       }
     },

--- a/test/WebApiShimFw46.FunctionalTests/project.json
+++ b/test/WebApiShimFw46.FunctionalTests/project.json
@@ -31,7 +31,7 @@
         "Microsoft.Extensions.CodeGenerators.Mvc": "1.0.0-rc2-*",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002520"
+          "version": "1.0.0-*"
         }
       }
     },


### PR DESCRIPTION
- Quick pulse metric stream is now enabled by default, and is the first telemetry processor. Default addition can be controlled using service option: ```EnableQuickPulseMetricStream```

- Fixing minor dependency warnings in functional tests that are causing build to fail. 