### PR TITLE
Fix dotnet-test-xunit dependency which causes tests to fail in net451…

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key="Aspnet Release Old" value="https://myget.org/f/aspnetrelease" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/test/EmptyApp.FunctionalTests/project.json
+++ b/test/EmptyApp.FunctionalTests/project.json
@@ -10,7 +10,7 @@
     "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-final",
     "FunctionalTestUtils": { "target": "project" },
     "Microsoft.NETCore.Platforms": "1.0.1-*",
-    "dotnet-test-xunit": "1.0.0-*",
+    "dotnet-test-xunit": "1.0.0-rc2-187791-49",
     "xunit": "2.1.0"
   },
   "testRunner": "xunit",

--- a/test/FunctionalTestUtils/project.json
+++ b/test/FunctionalTestUtils/project.json
@@ -5,7 +5,7 @@
     "preserveCompilationContext": true
   },
   "dependencies": {
-    "dotnet-test-xunit": "1.0.0-*",
+    "dotnet-test-xunit": "1.0.0-rc2-187791-49",
     "Microsoft.AspNetCore.Http.Abstractions": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",

--- a/test/MVCFramework45.FunctionalTests/project.json
+++ b/test/MVCFramework45.FunctionalTests/project.json
@@ -42,7 +42,7 @@
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-*"
+    "dotnet-test-xunit": "1.0.0-rc2-187791-49"
   },
   "testRunner": "xunit",
   "frameworks": {

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/project.json
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/project.json
@@ -17,7 +17,7 @@
     "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-*",
+    "dotnet-test-xunit": "1.0.0-rc2-187791-49",
     "Microsoft.ApplicationInsights.AspNetCore": { "target": "project" },
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final"
   },

--- a/test/WebApiShimFw46.FunctionalTests/project.json
+++ b/test/WebApiShimFw46.FunctionalTests/project.json
@@ -17,7 +17,7 @@
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
     "Microsoft.AspNet.WebApi.Client": "5.2.2",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
-    "dotnet-test-xunit": "1.0.0-*",
+    "dotnet-test-xunit": "1.0.0-rc2-187791-49",
     "xunit": "2.1.0",
     "Microsoft.VisualStudio.Web.CodeGeneration.Utils": "1.0.0-preview1-final"
   },


### PR DESCRIPTION
Fix dotnet-test-xunit dependency which causes tests to fail in net451 on local box.

The bits in nuget have an issue. 