### PR TITLE
Updated dirs.proj to build target only the core library.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <add key="Aspnet Release Old" value="https://myget.org/f/aspnetrelease" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/Signing.props
+++ b/Signing.props
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <!-- TODO: Figure out how to get signing to work in MicroBuildV2 for .xproj without using this "unsupported" manual approach. -->
+        <PathToSigningDll>$(BUILD_ARTIFACTSTAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.Signing.1.0.200\build\MicroBuild.Signing.dll</PathToSigningDll>
+        <RunningInMicroBuild Condition="Exists('$(AGENT_BUILDDIRECTORY)')">true</RunningInMicroBuild>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>$(CommonBuildPropsLocation)\Keys\InternalKey.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(PublicRelease)' == 'True'">
+        <DefineConstants>$(DefineConstants);PUBLIC_RELEASE</DefineConstants>
+        <DelaySign>true</DelaySign>
+        <AssemblyOriginatorKeyFile>$(CommonBuildPropsLocation)\Keys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
+
+    <ItemDefinitionGroup>
+        <FilesToSign>
+            <!-- Microsoft authenticode certificate for all file types -->
+            <Authenticode Condition="'%(FilesToSign.Authenticode)' == ''">Microsoft</Authenticode>
+            <!-- Microsoft strong-name key for managed assemblies -->
+            <StrongName Condition="'$(TargetExt)' == '.winmdobj' OR '$(TargetExt)' == '.dll' OR '$(TargetExt)' == '.exe'">MsSharedLib72</StrongName>
+        </FilesToSign>
+    </ItemDefinitionGroup>
+
+    <UsingTask TaskName="SignFiles" AssemblyFile="$(PathToSigningDll)" Condition="'$(RunningInMicroBuild)' == 'true'" />
+
+    <Target Name="SignFiles" AfterTargets="AfterBuild" DependsOnTargets="AfterBuild">
+        <SignFiles Condition="'$(RunningInMicroBuild)' == 'true'"
+            Files="@(FilesToSign)"
+            BinariesDirectory="$([System.IO.Path]::GetDirectoryName(%(FilesToSign.FullPath)))"
+            IntermediatesDirectory="$([System.IO.Path]::GetDirectoryName(%(FilesToSign.FullPath)))"
+            Type="$(SignType)" />
+    </Target>
+</Project>

--- a/dirs.proj
+++ b/dirs.proj
@@ -1,9 +1,126 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup>
-		<Solution Include="ApplicationInsights.AspNet.sln" />
-	</ItemGroup>
-	<Target Name="Build">
-		<MSBuild Projects="@(Solution)" ContinueOnError="ErrorAndStop" ToolsVersion="14.0"/>
-	</Target>
+    <Import Project="Signing.props"/>
+
+    <PropertyGroup>
+        <CliZipFile>$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-dev-win-x64.latest.zip</CliZipFile>
+        <CliToolsPath>$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-dev-win-x64.latest</CliToolsPath>
+        <ProjectToBuild>.\src\Microsoft.ApplicationInsights.AspNetCore\project.json</ProjectToBuild>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Solution Include="src\Microsoft.ApplicationInsights.AspNetCore\Microsoft.ApplicationInsights.AspNetCore.xproj" />
+    </ItemGroup>
+
+    <UsingTask TaskName="DownloadFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+        <ParameterGroup>
+            <Address ParameterType="System.String" Required="true"/>
+            <FileName ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Reference Include="System" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                    new System.Net.WebClient().DownloadFile(Address, FileName);
+                ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+
+    <UsingTask TaskName="ExtractZipArchive" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+        <ParameterGroup>
+            <InputFiles ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+            <OutputPath ParameterType="System.String" Required="true" />
+            <ArchiveFileNameAsRootFolder ParameterType="System.Boolean" Required="false" />
+            <Overwrite ParameterType="System.Boolean" Required="false" />
+        </ParameterGroup>
+        <Task>
+            <Reference Include="System" />
+            <Reference Include="System.IO.Compression" />
+            <Reference Include="System.IO.Compression.FileSystem" />
+
+            <Using Namespace="System.Diagnostics" />
+            <Using Namespace="System.IO" />
+            <Using Namespace="System.IO.Compression" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                    foreach (var inputFilePath in InputFiles.Select(f => f.ItemSpec))
+                    {
+                        using (ZipArchive archive = ZipFile.OpenRead(inputFilePath))
+                        {
+                            string inputFileName = Path.GetFileName(inputFilePath);
+                            if (true == ArchiveFileNameAsRootFolder && true == Overwrite)
+                            {
+                                DirectoryInfo archiveDirectory = new DirectoryInfo(Path.Combine(OutputPath, inputFileName));
+                                if (true == archiveDirectory.Exists)
+                                {
+                                    Log.LogMessage ("Archive root folder already exists, deleting path:{0}", archiveDirectory.FullName);
+                                    archiveDirectory.Delete(recursive: true);
+                                }
+                            }
+
+                            foreach (ZipArchiveEntry entry in archive.Entries)
+                            {
+                                string path = ArchiveFileNameAsRootFolder 
+                                    ? Path.Combine(OutputPath, inputFileName, entry.FullName)
+                                    : Path.Combine(OutputPath, entry.FullName);
+
+                                FileInfo fileInfo = new FileInfo(path);
+                                DirectoryInfo directoryInfo = new DirectoryInfo(fileInfo.DirectoryName);
+                                if (false == directoryInfo.Exists)
+                                {
+                                    Log.LogMessage ("Creating directory for archive entry, path:{0}", directoryInfo.FullName);
+                                    directoryInfo.Create();
+                                }
+
+                                Log.LogMessage("Extracting entry to path:{0}", path);
+                                entry.ExtractToFile(path, Overwrite);
+                            }
+                        }
+                    }
+                ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+
+    <Target Name="CheckBuildParameters">
+        <Message Importance="high" Text="ComputerName: $(ComputerName)"></Message>
+        <Message Importance="high" Text="User: $(USERDOMAIN)\$(USERNAME)"></Message>
+        <Message Importance="high" Text="RunningInMicroBuild: $(RunningInMicroBuild)"></Message>
+        <Message Importance="high" Text="CLI Zip: $(CliZipFile)"></Message>
+        <Message Importance="high" Text="CLI Tools Path: $(CliToolsPath)"></Message>
+    </Target>
+
+    <Target Name="DownloadCLI">
+        <DownloadFile Address="https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/Latest/dotnet-dev-win-x64.latest.zip" FileName="$(CliZipFile)" />
+        <ExtractZipArchive InputFiles="$(CliZipFile)" OutputPath="$(CliToolsPath)" ArchiveFileNameAsRootFolder="false" Overwrite="true"/>
+    </Target>
+
+    <Target Name="Build" DependsOnTargets="CheckBuildParameters;DownloadCLI">
+        <Exec Command='"$(CliToolsPath)\dotnet.exe" restore $(ProjectToBuild)' ContinueOnError="ErrorAndStop" />
+        <Exec Command='"$(CliToolsPath)\dotnet.exe" build $(ProjectToBuild) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
+    </Target>
+
+    <Target Name="Clean">
+        <RemoveDir Directories="$(BinRoot)\$(Configuration)" />
+        <RemoveDir Directories="$(BaseIntermediateOutputPath)" />
+        <RemoveDir Directories="$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-dev-win-x64.latest" />
+        <Delete Files="$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-dev-win-x64.latest.zip" />
+    </Target>
+
+    <Target Name="AfterBuild" AfterTargets="Build" DependsOnTargets="Build">
+        <ItemGroup>
+            <FilesToSign Include="**\Microsoft.ApplicationInsights.AspNetCore.dll">
+                <Authenticode Condition="'%(FilesToSign.Authenticode)' == ''">Microsoft</Authenticode>
+                <StrongName Condition="'%(FilesToSign.StrongName)' == ''">MsSharedLib72</StrongName>
+            </FilesToSign>
+        </ItemGroup>
+        <Message Importance="high" Text="Files to sign:"></Message>
+        <Message Importance="high" Text="--> File:%(FilesToSign.FileName)%(FilesToSign.Extension)
+        --> BinariesDirectory:$([System.IO.Path]::GetDirectoryName(%(FilesToSign.FullPath))) --> Authenticode:%(FilesToSign.Authenticode)"></Message>
+    </Target>
+
+    <Target Name="PackageNuGet" AfterTargets="SignFiles" DependsOnTargets="AfterBuild;SignFiles">
+        <Exec Command='"$(CliToolsPath)\dotnet.exe" pack $(ProjectToBuild) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
+    </Target>
 </Project>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/project.json
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "title": "Application Insights for ASP.NET Core Web Applications",
   "description": "Application Insights for ASP.NET Core web applications. See https://azure.microsoft.com/en-us/documentation/articles/app-insights-asp-net-five/ for more information.",
   "authors": [ "Microsoft" ],


### PR DESCRIPTION
Updated dirs.proj to build target only the core library.
Added DownloadFile and ExtractZipArchive tasks.
Added FilesToSign and Signing.props and output messages.
Added Clean, CheckBuildParameters, DownloadCLI, AfterBuild, and PackageNuGet Targets .
Added dotnet CLI zip file download and extract and switched to dotnet build from msbuild.