### PR TITLE
Update JS snippet from the ApplicationInsights-JS repo

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Resources.Designer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Resources.Designer.cs
@@ -61,8 +61,8 @@ namespace Microsoft.ApplicationInsights.AspNetCore {
         
         /// <summary>
         ///    Looks up a localized string similar to      &lt;script type=&quot;text/javascript&quot;&gt;
-        ///        var appInsights=window.appInsights||function(config){{
-        ///            function r(config){{t[config]=function(){{var i=arguments;t.queue.push(function(){{t[config].apply(t,i)}})}}}}var t={{config:config}},u=document,e=window,o=&quot;script&quot;,s=u.createElement(o),i,f;s.src=config.url||&quot;//az416426.vo.msecnd.net/scripts/a/ai.0.js&quot;;u.getElementsByTagName(o)[0].parentNode.appendChild(s);try{{t.cookie=u.cookie}}catch(h){{}}for(t.queue=[],i=[&quot;Event&quot;,&quot;Exception&quot;,&quot;Metric&quot;,&quot;PageVie [rest of string was truncated]&quot;;.
+        ///        var appInsights=window.appInsights||function(n){{
+        ///            function t(n){{i[n]=function(){{var t=arguments;i.queue.push(function(){{i[n].apply(i,t)}})}}}}var i={{config:n}},u=document,e=window,o=&quot;script&quot;,s=&quot;AuthenticatedUserContext&quot;,h=&quot;start&quot;,c=&quot;stop&quot;,l=&quot;Track&quot;,a=l+&quot;Event&quot;,v=l+&quot;Page&quot;,y=u.createElement(o),r,f;y.src=n.url||&quot;//az416426.vo.msecnd.net/scripts/a/ai.0.js&quot;;u.getElementsByTagName(o)[0].parentNode.appendChild(y);try{{i.cookie=u.cookie}}catch(p){{}}for( [rest of string was truncated]&quot;;.
         /// </summary>
         public static string JavaScriptSnippet {
             get {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Resources.resx
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Resources.resx
@@ -119,12 +119,12 @@
   </resheader>
   <data name="JavaScriptSnippet" xml:space="preserve">
     <value>    &lt;script type="text/javascript"&gt;
-        var appInsights=window.appInsights||function(config){{
-            function r(config){{t[config]=function(){{var i=arguments;t.queue.push(function(){{t[config].apply(t,i)}})}}}}var t={{config:config}},u=document,e=window,o="script",s=u.createElement(o),i,f;s.src=config.url||"//az416426.vo.msecnd.net/scripts/a/ai.0.js";u.getElementsByTagName(o)[0].parentNode.appendChild(s);try{{t.cookie=u.cookie}}catch(h){{}}for(t.queue=[],i=["Event","Exception","Metric","PageView","Trace","Dependency"];i.length;)r("track"+i.pop());return r("setAuthenticatedUserContext"),r("clearAuthenticatedUserContext"),config.disableExceptionTracking||(i="onerror",r("_"+i),f=e[i],e[i]=function(config,r,u,e,o){{var s=f&amp;&amp;f(config,r,u,e,o);return s!==!0&amp;&amp;t["_"+i](config,r,u,e,o),s}}),t
+        var appInsights=window.appInsights||function(n){{
+            function t(n){{i[n]=function(){{var t=arguments;i.queue.push(function(){{i[n].apply(i,t)}})}}}}var i={{config:n}},u=document,e=window,o="script",s="AuthenticatedUserContext",h="start",c="stop",l="Track",a=l+"Event",v=l+"Page",y=u.createElement(o),r,f;y.src=n.url||"//az416426.vo.msecnd.net/scripts/a/ai.0.js";u.getElementsByTagName(o)[0].parentNode.appendChild(y);try{{i.cookie=u.cookie}}catch(p){{}}for(i.queue=[],r=["Event","Exception","Metric","PageView","Trace","Dependency"];r.length;)t("track"+r.pop());return t("set"+s),t("clear"+s),t(h+a),t(c+a),t(h+v),t(c+v),t("flush"),n.disableExceptionTracking||(r="onerror",t("_"+r),f=e[r],e[r]=function(n,t,u,e,o){{var s=f&amp;&amp;f(n,t,u,e,o);return s!==!0&amp;&amp;i["_"+r](n,t,u,e,o),s}}),i
         }}({{
             instrumentationKey: '{0}'
         }});
-        
+
         window.appInsights=appInsights;
         appInsights.trackPageView();
     &lt;/script&gt;


### PR DESCRIPTION
This updates the JS snippet from the latest in the ApplicationInsights-JS repo. I've left in the minor differences of course like the {0} for the inst key and CDN path.

See Microsoft/ApplicationInsights-JS#295 for additional context.