### PR TITLE
Marked the analyzers for build only and not NuGet packaging.  Rev'ed versioning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.0.2
+
+- Marked code analysis packages as only for build and not NuGet package dependencies.
+
 ## Version 1.0.1
 
 - Added code analysis packages.

--- a/SetEnv.targets
+++ b/SetEnv.targets
@@ -5,7 +5,7 @@
 			Date when Semantic Version was changed. 
 			Update for every public release.
 		-->
-		<SemanticVersionDate>2015-6-1</SemanticVersionDate>
+		<SemanticVersionDate>2016-9-28</SemanticVersionDate>
 		<!--
 			Pre-release version is used to distinguish internally built NuGet packages.
 			Pre-release version = Minutes since semantic version was set, divided by 5 (to make it fit in a UInt16).

--- a/src/Microsoft.ApplicationInsights.AspNetCore/project.json
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/project.json
@@ -3,7 +3,7 @@
   "summary": "Application Insights for ASP.NET Core web applications.",
   "description": "Application Insights for ASP.NET Core web applications. See https://azure.microsoft.com/en-us/documentation/articles/app-insights-asp-net-five/ for more information. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156",
   "authors": [ "Microsoft" ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "copyright": "Copyright © Microsoft. All Rights Reserved.",
   "packOptions": {
     "projectUrl": "http://go.microsoft.com/fwlink/?LinkId=392727",
@@ -22,28 +22,73 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "Desktop.Analyzers": "1.2.0-beta2",
-    "Microsoft.ApiDesignGuidelines.Analyzers": "1.2.0-beta2",
+    "Desktop.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    },
+    "Microsoft.ApiDesignGuidelines.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    },
     "Microsoft.ApplicationInsights": "2.1.0",
     "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0",
     "Microsoft.AspNetCore.Http.Abstractions": "1.0.0",
     "Microsoft.AspNetCore.Mvc.ViewFeatures": "1.0.1",
-    "Microsoft.CodeAnalysis.Analyzers": "1.2.0-beta2",
-    "Microsoft.Composition.Analyzers": "1.2.0-beta2",
+    "Microsoft.CodeAnalysis.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    },
+    "Microsoft.Composition.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    },
     "Microsoft.Extensions.Configuration": "1.0.0",
     "Microsoft.Extensions.DiagnosticAdapter": "1.0.0",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
-    "Microsoft.Maintainability.Analyzers": "1.2.0-beta2",
-    "Microsoft.QualityGuidelines.Analyzers": "1.2.0-beta2",
-    "Roslyn.Diagnostics.Analyzers": "1.2.0-beta2",
-    "System.Collections.Immutable.Analyzers": "1.2.0-beta2",
-    //"System.Resources.Analyzers": "1.2.0-beta2",
-    "System.Runtime.Analyzers": "1.2.0-beta2",
-    "System.Runtime.InteropServices.Analyzers": "1.2.0-beta2",
-    //"System.Security.Cryptography.Hashing.Algorithms.Analyzers": "1.2.0-beta2",
-    "System.Threading.Tasks.Analyzers": "1.2.0-beta2"
-    //"Text.Analyzers": "1.2.0-beta2",
-    //"XmlDocumentationComments.Analyzers": "1.2.0-beta2"
+    "Microsoft.Maintainability.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    },
+    "Microsoft.QualityGuidelines.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    },
+    "Roslyn.Diagnostics.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    },
+    "System.Collections.Immutable.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    },
+    //"System.Resources.Analyzers": {
+    //    "version": "1.2.0-beta2",
+    //    "type": "build"
+    //},
+    "System.Runtime.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    },
+    "System.Runtime.InteropServices.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    },
+    //"System.Security.Cryptography.Hashing.Algorithms.Analyzers": {
+    //    "version": "1.2.0-beta2",
+    //    "type": "build"
+    //},
+    "System.Threading.Tasks.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+    }
+    //"Text.Analyzers": {
+    //    "version": "1.2.0-beta2",
+    //    "type": "build"
+    //},
+    //"XmlDocumentationComments.Analyzers": {
+    //    "version": "1.2.0-beta2",
+    //    "type": "build"
+    //},
   },
 
   "frameworks": {

--- a/test/EmptyApp.FunctionalTests/project.json
+++ b/test/EmptyApp.FunctionalTests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "webroot": "wwwroot",
   "buildOptions": {
     "keyFile": "../../keys/35MSSharedLib1024.snk",

--- a/test/FunctionalTestUtils/project.json
+++ b/test/FunctionalTestUtils/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "buildOptions": {
     "keyFile": "../../keys/35MSSharedLib1024.snk",
     "delaySign": true,

--- a/test/MVCFramework45.FunctionalTests/project.json
+++ b/test/MVCFramework45.FunctionalTests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "userSecretsId": "aspnet-MVCFramework45.FunctionalTests-60cfc765-2dc9-454c-bb34-dc379ed92cd0",
   "buildOptions": {
     "keyFile": "../../keys/35MSSharedLib1024.snk",

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/project.json
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "buildOptions": {
     "keyFile": "../../keys/35MSSharedLib1024.snk",
     "delaySign": true,

--- a/test/WebApiShimFw46.FunctionalTests/project.json
+++ b/test/WebApiShimFw46.FunctionalTests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "webroot": "wwwroot",
   "buildOptions": {
     "keyFile": "../../keys/35MSSharedLib1024.snk",


### PR DESCRIPTION
Should fix [https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/272](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/272)