### PR TITLE
Trying to prevent the weird test timing issues.

### DIFF
--- a/test/WebApiShimFw46.FunctionalTests/project.json
+++ b/test/WebApiShimFw46.FunctionalTests/project.json
@@ -6,7 +6,7 @@
     "delaySign": true,
     "preserveCompilationContext": true,
     "copyToOutput": {
-      "includeFiles": [ "config.json" ]
+      "includeFiles": [ "config.json", "xunit.runner.json" ]
     }
   },
   "testRunner": "xunit",

--- a/test/WebApiShimFw46.FunctionalTests/xunit.runner.json
+++ b/test/WebApiShimFw46.FunctionalTests/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+    "parallelizeAssembly": false,
+    "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Added xunit runner config file to prevent test parallelization.
Changed formatting, cleared the buffer and checked for the right named object, and added locking.
Subtracted 50 milliseconds from the test start time to compensate for the build lab reporting earlier timestamps for telemetry items.