### PR TITLE
Update HttpContext.TraceIdenfier with Telemetry.Name

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs
@@ -31,6 +31,8 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
                 {
                     name = httpContext.Request.Method + " " + name;
                     telemetry.Name = name;
+                    // Append the name to HttpContext.TraceIdentifier so that it can be consumsed by other parties through System.Diagnostics.DiagnosticSourceEventSource
+                    httpContext.TraceIdentifier += "|" + name;
                 }
             }
         }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/DiagnosticListeners/Implementation/MvcDiagnosticsListenerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/DiagnosticListeners/Implementation/MvcDiagnosticsListenerTests.cs
@@ -1,0 +1,39 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests.MvcDiagnosticsListener
+{
+    using DataContracts;
+    using DiagnosticListeners;
+    using Helpers;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Routing;
+    using System.Diagnostics;
+    using Xunit;
+
+    public class MvcDiagnosticsListenerTests
+    {
+        [Fact]
+        public void SetsTelemetryNameFromRouteData()
+        {
+            var actionContext = new ActionContext();
+            actionContext.RouteData = new RouteData();
+            actionContext.RouteData.Values.Add("controller", "account");
+            actionContext.RouteData.Values.Add("action", "login");
+            actionContext.RouteData.Values.Add("parameter", "myName");
+
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
+            string originalTraceIdentifier = contextAccessor.HttpContext.TraceIdentifier;
+
+            var telemetryListener = new DiagnosticListener(TestListenerName);
+            var mvcListener = new MvcDiagnosticsListener();
+            telemetryListener.SubscribeWithAdapter(mvcListener);
+            telemetryListener.Write("Microsoft.AspNetCore.Mvc.BeforeAction",
+                new { httpContext = contextAccessor.HttpContext, routeData = actionContext.RouteData });
+
+            var telemetry = contextAccessor.HttpContext.Features.Get<RequestTelemetry>();
+
+            Assert.Equal("GET account/login [parameter]", telemetry.Name);
+            Assert.Equal(originalTraceIdentifier + "|" + telemetry.Name, contextAccessor.HttpContext.TraceIdentifier);
+        }
+
+        private const string TestListenerName = "TestListener";
+    }
+}

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
@@ -1,12 +1,10 @@
-﻿using Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners;
-
-namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
 {
     using System;
     using System.Diagnostics;
-    using System.Diagnostics.Tracing;
     using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
     using Microsoft.ApplicationInsights.AspNetCore.Tests.Helpers;
+    using Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http.Internal;


### PR DESCRIPTION
Update HttpContext.TraceIdentifier with Telemetry.Name generated in MvcDiagnosticsListener.

The motivation of the change is described in #321 

