### PR TITLE
Use accurate timestamps in HostingDiagnosticListener

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -43,7 +43,7 @@
                     Id = httpContext.TraceIdentifier
                 };
                 this.client.Initialize(requestTelemetry);
-                requestTelemetry.Start(/*timestamp*/);
+                requestTelemetry.Start(timestamp);
                 httpContext.Features.Set(requestTelemetry);
 
                 IHeaderDictionary responseHeaders = httpContext.Response?.Headers;
@@ -102,7 +102,7 @@
                     return;
                 }
 
-                telemetry.Stop(/*timestamp*/);
+                telemetry.Stop(timestamp);
                 telemetry.ResponseCode = httpContext.Response.StatusCode.ToString();
 
                 var successExitCode = httpContext.Response.StatusCode < 400;

--- a/src/Microsoft.ApplicationInsights.AspNetCore/project.json
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/project.json
@@ -30,7 +30,7 @@
             "version": "1.2.0-beta2",
             "type": "build"
         },
-        "Microsoft.ApplicationInsights": "2.2.0",
+      "Microsoft.ApplicationInsights": "2.3.0-beta3",
         "Microsoft.AspNetCore.Hosting": "1.0.0",
         "Microsoft.Extensions.Configuration": "1.0.0",
         "Microsoft.Extensions.Configuration.Json": "1.0.0",
@@ -76,27 +76,27 @@
         //    "version": "1.2.0-beta2",
         //    "type": "build"
         //},
-        "System.Threading.Tasks.Analyzers": {
-            "version": "1.2.0-beta2",
-            "type": "build"
-        }
-        //"Text.Analyzers": {
-        //    "version": "1.2.0-beta2",
-        //    "type": "build"
-        //},
-        //"XmlDocumentationComments.Analyzers": {
-        //    "version": "1.2.0-beta2",
-        //    "type": "build"
-        //},
+      "System.Threading.Tasks.Analyzers": {
+        "version": "1.2.0-beta2",
+        "type": "build"
+      }
+      //"Text.Analyzers": {
+      //    "version": "1.2.0-beta2",
+      //    "type": "build"
+      //},
+      //"XmlDocumentationComments.Analyzers": {
+      //    "version": "1.2.0-beta2",
+      //    "type": "build"
+      //},
     },
 
     "frameworks": {
         "net451": {
-            "dependencies": {
-                "Microsoft.ApplicationInsights.DependencyCollector": "2.2.0",
-                "Microsoft.ApplicationInsights.PerfCounterCollector": "2.2.0",
-                "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.2.0"
-            }
+          "dependencies": {
+            "Microsoft.ApplicationInsights.DependencyCollector": "2.3.0-beta3",
+            "Microsoft.ApplicationInsights.PerfCounterCollector": "2.3.0-beta3",
+            "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.3.0-beta3"
+          }
         },
         "netstandard1.6": {
             "dependencies": {

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/RequestTrackingMiddlewareTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/RequestTrackingMiddlewareTest.cs
@@ -284,7 +284,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests
             Assert.NotEqual(id1, id2);
         }
 
-        [Fact(Skip = "Disabled until timestamp overloads are supported in OperationTelemetryExtensions.Start/Stop. https://github.com/Microsoft/ApplicationInsights-dotnet/pull/424")]
+        [Fact]
         public void SimultaneousRequestsGetCorrectDurations()
         {
             var context1 = new DefaultHttpContext();
@@ -312,7 +312,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests
             Assert.Equal(TimeSpan.FromSeconds(9), ((RequestTelemetry)sentTelemetry[1]).Duration);
         }
 
-        [Fact(Skip = "Disabled until precise durations are supported in OperationTelemetryExtensions.Start/Stop. https://github.com/Microsoft/ApplicationInsights-dotnet/pull/426")]
+        [Fact]
         public void OnEndRequestSetsPreciseDurations()
         {
             var context = new DefaultHttpContext();


### PR DESCRIPTION
Also upgrades references to 2.3.0-beta3.
Takes advantage of the overloads of Start/Stop that were added for https://github.com/Microsoft/ApplicationInsights-dotnet/pull/424