### PR TITLE
Fix OperationIdOfRequestIsPropagatedToChildDependency and TestBasicDependencyPropertiesAfterRequestingBasicPage functional tests

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ApplicationInsightsInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ApplicationInsightsInitializer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore
         /// </summary>
         public void Start()
         {
-            DiagnosticListener.AllListeners.Subscribe(this);
+            this.subscriptions.Add(DiagnosticListener.AllListeners.Subscribe(this));
         }
 
         /// <inheritdoc />

--- a/test/FunctionalTestUtils/BackTelemetryChannel.cs
+++ b/test/FunctionalTestUtils/BackTelemetryChannel.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-
-namespace FunctionalTestUtils
+﻿namespace FunctionalTestUtils
 {
     using System;
     using System.Collections.Generic;
@@ -38,12 +36,11 @@ namespace FunctionalTestUtils
         {
             get
             {
-                return string.Empty;
+                return "https://dc.services.visualstudio.com/v2/track";
             }
 
             set
             {
-                this.EndpointAddress = string.Empty;
             }
         }
 

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
@@ -1,4 +1,6 @@
-﻿namespace SampleWebAppIntegration.FunctionalTest
+﻿using System.Diagnostics;
+
+namespace SampleWebAppIntegration.FunctionalTest
 {
     using System;
     using System.Collections.Generic;
@@ -21,6 +23,7 @@
             // Verify operation of OperationIdTelemetryInitializer
             string path = "Home/Dependency";
             InProcessServer server;
+
             using (server = new InProcessServer(assemblyName, InProcessServer.UseApplicationInsights))
             {
                 using (var httpClient = new HttpClient())
@@ -34,8 +37,15 @@
             try
             {
                 Assert.True(telemetries.Count >= 2);
-                Assert.Equal(2, telemetries.Where((t) => t.Context?.Operation?.Name != null && t.Context.Operation.Name.Contains(path)).Count());
-                Assert.Equal(telemetries[0].Context.Operation.Id, telemetries[1].Context.Operation.Id);
+                Assert.Equal(2, telemetries.Count(t => t.Context?.Operation?.Name != null && t.Context.Operation.Name.Contains(path)));
+                var dependency = (DependencyTelemetry)telemetries.Single(t =>
+                {
+                    var dt = t as DependencyTelemetry;
+                    return dt?.Context?.Operation?.Name != null && dt.Context.Operation.Name.Contains(path);
+                });
+
+                var request = (RequestTelemetry)telemetries.Single(t => t is RequestTelemetry);
+                Assert.Equal(dependency.Context.Operation.Id, request.Context.Operation.Id);
             }
             catch (Exception e)
             {

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
@@ -45,7 +45,7 @@ namespace SampleWebAppIntegration.FunctionalTest
                 });
 
                 var request = (RequestTelemetry)telemetries.Single(t => t is RequestTelemetry);
-                Assert.Equal(dependency.Context.Operation.Id, request.Context.Operation.Id);
+                Assert.Equal(request.Context.Operation.Id, dependency.Context.Operation.Id);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
1. OperationIdOfRequestIsPropagatedToChildDependency:
 - was failing because CorrelationIdLookupHelper was not set up properly and test was checking internal AI trace message instead on dependency telemetry
 - was failing because there are 2 dependencies: one is call to application from the test, another one was reported in the controller

2. TestBasicDependencyPropertiesAfterRequestingBasicPage 
was failing because AI was not disposed properly and magically application was using old telemetry channel remaining from the previous test and test was checking new telemetry channel.
While the magic that kept TelemetryChannel alive is still unknown, AI is now properly disposed and test is fixed.