### PR TITLE
Enable dependency collector for .Net core framework

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -134,6 +134,7 @@
             services.AddSingleton<ITelemetryInitializer, WebSessionTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebUserTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, AspNetCoreEnvironmentTelemetryInitializer>();
+            services.AddSingleton<ITelemetryInitializer, HttpDependenciesParsingTelemetryInitializer>();
             services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>();
 
 #if NET451

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -9,6 +9,7 @@
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.AspNetCore.Logging;
     using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
+    using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
@@ -18,7 +19,6 @@
     using Microsoft.Extensions.Options;
 
 #if NET451
-    using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
 #endif
 
@@ -134,10 +134,10 @@
             services.AddSingleton<ITelemetryInitializer, WebSessionTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, WebUserTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, AspNetCoreEnvironmentTelemetryInitializer>();
+            services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>();
 
 #if NET451
             services.AddSingleton<ITelemetryModule, PerformanceCollectorModule>();
-            services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>();
 #endif
             services.AddSingleton<TelemetryConfiguration>(provider => provider.GetService<IOptions<TelemetryConfiguration>>().Value);
 

--- a/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
+++ b/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
@@ -60,6 +60,8 @@
             var telemetries = server.BackChannel.Buffer;
 #if NET451
             Assert.Contains(telemetries.OfType<DependencyTelemetry>(), t => t.Name == "/Mixed");
+#else
+            Assert.Contains(telemetries.OfType<DependencyTelemetry>(), t => t.Name == "GET /Mixed");
 #endif
 
             Assert.True(telemetries.Count >= 4);

--- a/test/EmptyApp.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
+++ b/test/EmptyApp.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
@@ -12,9 +12,7 @@
         [Fact]
         public void TestBasicDependencyPropertiesAfterRequestingBasicPage()
         {
-#if NET451
             this.ValidateBasicDependency(assemblyName, "/");
-#endif
         }
 
         [Fact]

--- a/test/FunctionalTestUtils/BackTelemetryChannel.cs
+++ b/test/FunctionalTestUtils/BackTelemetryChannel.cs
@@ -38,12 +38,11 @@ namespace FunctionalTestUtils
         {
             get
             {
-                return string.Empty;
+                return "https://dc.services.visualstudio.com/v2/track";
             }
 
             set
             {
-                this.EndpointAddress = string.Empty;
             }
         }
 

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
@@ -34,8 +34,9 @@
             try
             {
                 Assert.True(telemetries.Count >= 2);
-                Assert.Equal(2, telemetries.Where((t) => t.Context?.Operation?.Name != null && t.Context.Operation.Name.Contains(path)).Count());
-                Assert.Equal(telemetries[0].Context.Operation.Id, telemetries[1].Context.Operation.Id);
+                var requestTelemetry = telemetries.OfType<RequestTelemetry>().Single();
+                var dependencyTelemetry = telemetries.OfType<DependencyTelemetry>().First(t => t.Name == "MyDependency");
+                Assert.Equal(requestTelemetry.Context.Operation.Id, dependencyTelemetry.Context.Operation.Id);
             }
             catch (Exception e)
             {
@@ -65,12 +66,9 @@
             try
             {
                 Assert.NotNull(telemetries);
-                Assert.Equal(2, telemetries.Count());
-                DependencyTelemetry dependency = telemetries.OfType<DependencyTelemetry>().FirstOrDefault();
-                Assert.NotNull(dependency);
-                RequestTelemetry request = telemetries.OfType<RequestTelemetry>().FirstOrDefault();
-                Assert.NotNull(request);
-                Assert.Equal(request.Id, dependency.Context.Operation.ParentId);
+                var requestTelemetry = telemetries.OfType<RequestTelemetry>().Single();
+                var dependencyTelemetry = telemetries.First(t => t is DependencyTelemetry && (t as DependencyTelemetry).Name == "MyDependency");
+                Assert.Equal(requestTelemetry.Id, dependencyTelemetry.Context.Operation.ParentId);
             }
             catch (Exception e)
             {

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
@@ -79,6 +79,8 @@ namespace SampleWebAppIntegration.FunctionalTest
             var telemetries = server.BackChannel.Buffer;
 #if NET451
             Assert.Contains(telemetries.OfType<DependencyTelemetry>(), t => t.Name == "/Home/Contact");
+#else
+            Assert.Contains(telemetries.OfType<DependencyTelemetry>(), t => t.Name == "GET /Home/Contact");
 #endif
 
             Assert.True(telemetries.Count >= 4);

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
@@ -12,9 +12,7 @@
         [Fact]
         public void TestBasicDependencyPropertiesAfterRequestingBasicPage()
         {
-#if NET451
             this.ValidateBasicDependency(assemblyName, "/Home/About/5", InProcessServer.UseApplicationInsights);
-#endif
         }
 
         [Fact]

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
     using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
     using Microsoft.ApplicationInsights.AspNetCore.Tests;
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.AspNetCore.Hosting;
@@ -22,7 +23,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
     using Microsoft.Extensions.Options;
 
 #if NET451
-    using ApplicationInsights.DependencyCollector;
     using ApplicationInsights.Extensibility.PerfCounterCollector;
     using ApplicationInsights.WindowsServer.TelemetryChannel;
     using ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
@@ -297,7 +297,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 }
             }
 
-#if NET451
+
             [Fact]
             public static void RegistersTelemetryConfigurationFactoryMethodThatPopulatesItWithModulesFromContainer()
             {
@@ -305,15 +305,20 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
+
+#if NET451
                 Assert.Equal(2, modules.Count());
+                var perfCounterModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(PerformanceCollectorModule));
+                Assert.NotNull(perfCounterModule);
+#else
+                Assert.Equal(1, modules.Count());
+#endif
 
                 var dependencyModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(DependencyTrackingTelemetryModule));
                 Assert.NotNull(dependencyModule);
-
-                var perfCounterModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(PerformanceCollectorModule));
-                Assert.NotNull(perfCounterModule);
             }
 
+#if NET451
             [Fact]
             public static void AddsAddaptiveSamplingServiceToTheConfigurationInFullFrameworkByDefault()
             {

--- a/test/WebApiShimFw46.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
+++ b/test/WebApiShimFw46.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
@@ -14,9 +14,7 @@ namespace SampleWebAppIntegration.FunctionalTest
         [Fact]
         public void TestBasicDependencyPropertiesAfterRequestingBasicPage()
         {
-#if NET451
             this.ValidateBasicDependency(assemblyName, "/api/values");
-#endif
         }
 
         [Fact]


### PR DESCRIPTION
Enable dependency collector for .Net core framework and also fix unit tests