### PR TITLE
Fix issue #416. Add certain domains to dependency collector's exclude list

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -135,7 +135,16 @@
             services.AddSingleton<ITelemetryInitializer, WebUserTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, AspNetCoreEnvironmentTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, HttpDependenciesParsingTelemetryInitializer>();
-            services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>();
+            services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>(provider => {
+                var module = new DependencyTrackingTelemetryModule();
+                var excludedDomains = module.ExcludeComponentCorrelationHttpHeadersOnDomains;
+                excludedDomains.Add("core.windows.net");
+                excludedDomains.Add("core.chinacloudapi.cn");
+                excludedDomains.Add("core.cloudapi.de");
+                excludedDomains.Add("core.usgovcloudapi.net");
+
+                return module;
+            });
 
 #if NET451
             services.AddSingleton<ITelemetryModule, PerformanceCollectorModule>();

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/CorrelationMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/CorrelationMvcTests.cs
@@ -1,0 +1,39 @@
+﻿namespace MVCFramework45.FunctionalTests.FunctionalTest
+{
+    using FunctionalTestUtils;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using System;
+    using System.Linq;
+    using System.Net.Http;
+    using Xunit;
+
+    public class CorrelationMvcTests : TelemetryTestsBase
+    {
+        private const string assemblyName = "MVCFramework45.FunctionalTests";
+
+        [Fact]
+        public void CorrelationInfoIsPropagatedToDependendedService()
+        {
+#if !NET451 // Correlation is not supported in NET451. It works with NET46 and .Net core.
+            InProcessServer server;
+
+            using (server = new InProcessServer(assemblyName, InProcessServer.UseApplicationInsights))
+            {
+                using (var httpClient = new HttpClient())
+                {
+                    var task = httpClient.GetAsync(server.BaseHost + "/");
+                    task.Wait(TestTimeoutMs);
+                }
+            }
+
+            var telemetries = server.BackChannel.Buffer;
+
+            Assert.True(telemetries.Count >= 2);
+            var requestTelemetry = telemetries.OfType<RequestTelemetry>().Single();
+            var dependencyTelemetry = telemetries.OfType<DependencyTelemetry>().Single();
+            Assert.Equal(requestTelemetry.Context.Operation.Id, dependencyTelemetry.Context.Operation.Id);
+            Assert.Equal(requestTelemetry.Context.Operation.ParentId, dependencyTelemetry.Id);
+#endif
+        }
+    }
+}

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
@@ -20,38 +20,7 @@ namespace SampleWebAppIntegration.FunctionalTest
         private const string assemblyName = "MVCFramework45.FunctionalTests";
 
         [Fact]
-        public void OperationIdOfOutgoingRequestIsPropagated()
-        {
-#if !NET451 // Correlation is not supported in NET451. It works with NET46 and .Net core.
-            InProcessServer server;
-
-            using (server = new InProcessServer(assemblyName, InProcessServer.UseApplicationInsights))
-            {
-                using (var httpClient = new HttpClient())
-                {
-                    var task = httpClient.GetAsync(server.BaseHost + "/");
-                    task.Wait(TestTimeoutMs);
-                }
-            }
-
-            var telemetries = server.BackChannel.Buffer;
-            try
-            {
-                Assert.True(telemetries.Count >= 2);
-                var requestTelemetry = telemetries.OfType<RequestTelemetry>().Single();
-                var dependencyTelemetry = telemetries.OfType<DependencyTelemetry>().Single();
-                Assert.Equal(requestTelemetry.Context.Operation.Id, dependencyTelemetry.Context.Operation.Id);
-            }
-            catch (Exception e)
-            {
-                string data = DebugTelemetryItems(telemetries);
-                throw new Exception(data, e);
-            }
-#endif
-        }
-
-        [Fact]
-        public void OperationIdOfOutgoingRequestIsNotPropagatedIfDomainIsExcluded()
+        public void CorrelationInfoIsNotAddedToRequestHeaderIfUserAddDomainToExcludedList()
         {
 #if !NET451 // Correlation is not supported in NET451. It works with NET46 and .Net core.
             InProcessServer server;

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
@@ -11,10 +11,78 @@ namespace SampleWebAppIntegration.FunctionalTest
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.DependencyCollector;
+    using Microsoft.Extensions.DependencyInjection;
 
     public class DependencyTelemetryMvcTests : TelemetryTestsBase
     {
         private const string assemblyName = "MVCFramework45.FunctionalTests";
+
+        [Fact]
+        public void OperationIdOfOutgoingRequestIsPropagated()
+        {
+#if !NET451 // Correlation is not supported in NET451. It works with NET46 and .Net core.
+            InProcessServer server;
+
+            using (server = new InProcessServer(assemblyName, InProcessServer.UseApplicationInsights))
+            {
+                using (var httpClient = new HttpClient())
+                {
+                    var task = httpClient.GetAsync(server.BaseHost + "/");
+                    task.Wait(TestTimeoutMs);
+                }
+            }
+
+            var telemetries = server.BackChannel.Buffer;
+            try
+            {
+                Assert.True(telemetries.Count >= 2);
+                var requestTelemetry = telemetries.OfType<RequestTelemetry>().Single();
+                var dependencyTelemetry = telemetries.OfType<DependencyTelemetry>().Single();
+                Assert.Equal(requestTelemetry.Context.Operation.Id, dependencyTelemetry.Context.Operation.Id);
+            }
+            catch (Exception e)
+            {
+                string data = DebugTelemetryItems(telemetries);
+                throw new Exception(data, e);
+            }
+#endif
+        }
+
+        [Fact]
+        public void OperationIdOfOutgoingRequestIsNotPropagatedIfDomainIsExcluded()
+        {
+#if !NET451 // Correlation is not supported in NET451. It works with NET46 and .Net core.
+            InProcessServer server;
+
+            using (server = new InProcessServer(assemblyName, InProcessServer.UseApplicationInsights))
+            {
+                var dependencyCollectorModule = server.ApplicationServices.GetServices<ITelemetryModule>().OfType<DependencyTrackingTelemetryModule>().Single();
+                dependencyCollectorModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Add(server.BaseHost);
+
+                using (var httpClient = new HttpClient())
+                {
+                    var task = httpClient.GetAsync(server.BaseHost + "/");
+                    task.Wait(TestTimeoutMs);
+                }
+            }
+
+            var telemetries = server.BackChannel.Buffer;
+            try
+            {
+                Assert.True(telemetries.Count >= 2);
+                var requestTelemetry = telemetries.OfType<RequestTelemetry>().Single();
+                var dependencyTelemetry = telemetries.OfType<DependencyTelemetry>().Single();
+                Assert.NotEqual(requestTelemetry.Context.Operation.Id, dependencyTelemetry.Context.Operation.Id);
+            }
+            catch (Exception e)
+            {
+                string data = DebugTelemetryItems(telemetries);
+                throw new Exception(data, e);
+            }
+#endif
+        }
 
         [Fact]
         public void OperationIdOfRequestIsPropagatedToChildDependency()

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.Equal(1, modules.Count());
 #endif
 
-                var dependencyModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(DependencyTrackingTelemetryModule));
+                var dependencyModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationFactory?.GetMethodInfo().ReturnType == typeof(DependencyTrackingTelemetryModule));
                 Assert.NotNull(dependencyModule);
             }
 

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -314,8 +314,11 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.Equal(1, modules.Count());
 #endif
 
-                var dependencyModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationFactory?.GetMethodInfo().ReturnType == typeof(DependencyTrackingTelemetryModule));
-                Assert.NotNull(dependencyModule);
+                var dependencyModuleDescriptor = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationFactory?.GetMethodInfo().ReturnType == typeof(DependencyTrackingTelemetryModule));
+                Assert.NotNull(dependencyModuleDescriptor);
+
+                var dependencyModule = modules.OfType<DependencyTrackingTelemetryModule>().Single();
+                Assert.True(dependencyModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Count > 0);
             }
 
 #if NET451


### PR DESCRIPTION
Add some domains as a temporary workaround. Will probably be configurable when the configuration story is clear.