### PR TITLE
Align System.Net.NameResolution with NETStandard.Library

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/project.json
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/project.json
@@ -101,8 +101,7 @@
         "netstandard1.6": {
             "dependencies": {
                 "NETStandard.Library": "1.6.1",
-                "System.Net.NameResolution": "4.0.0",
-                "System.Diagnostics.StackTrace": "4.3.0"
+                "System.Net.NameResolution": "4.3.0"
             }
         }
     }


### PR DESCRIPTION
We see downgrade warnings during asp.net core build process. This PR aligns version of `System.Net.NameResolution` with one used by other packages from `NETStandard.Library 1.6.1` 
```
Detected package downgrade: System.Net.NameResolution from 4.3.0 to 4.0.0  [C:\b\w\590aeb6bc9b87cb8\.r\AzureIntegration\.build\KoreBuild.proj]
ApplicationInsightsHostingStartupSample (>= 1.0.0) -> Microsoft.AspNetCore.ApplicationInsights.HostingStartup (>= 2.0.0-preview1-24822) -> Microsoft.ApplicationInsights.AspNetCore (>= 2.1.0-beta2) -> NETStandard.Library (>= 1.6.1) -> System.Net.Sockets (>= 4.3.0) -> runtime.unix.System.Net.Sockets (>= 4.3.0) -> System.Net.NameResolution (>= 4.3.0)  [C:\b\w\590aeb6bc9b87cb8\.r\AzureIntegration\.build\KoreBuild.proj]
ApplicationInsightsHostingStartupSample (>= 1.0.0) -> Microsoft.AspNetCore.ApplicationInsights.HostingStartup (>= 2.0.0-preview1-24822) -> Microsoft.ApplicationInsights.AspNetCore (>= 2.1.0-beta2) -> System.Net.NameResolution (>= 4.0.0) [C:\b\w\590aeb6bc9b87cb8\.r\AzureIntegration\.build\KoreBuild.proj]

```