### PR TITLE
Ability to add telemetry processors through DI

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -1,6 +1,7 @@
 namespace Microsoft.Extensions.DependencyInjection
 {
     using System;
+    using System.Linq;
     using System.Collections.Generic;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.Channel;
@@ -21,6 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         private readonly IEnumerable<ITelemetryInitializer> initializers;
         private readonly IEnumerable<ITelemetryModule> modules;
         private readonly ITelemetryChannel telemetryChannel;
+        private readonly IEnumerable<Func<ITelemetryProcessor, ITelemetryProcessor>> telemetryProcessorFactories;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:TelemetryConfigurationOptionsSetup"/> class.
@@ -29,11 +31,13 @@ namespace Microsoft.Extensions.DependencyInjection
             IServiceProvider serviceProvider,
             IOptions<ApplicationInsightsServiceOptions> applicationInsightsServiceOptions,
             IEnumerable<ITelemetryInitializer> initializers,
-            IEnumerable<ITelemetryModule> modules)
+            IEnumerable<ITelemetryModule> modules,
+            IEnumerable<Func<ITelemetryProcessor, ITelemetryProcessor>> telemetryProcessorFactories)
         {
             this.applicationInsightsServiceOptions = applicationInsightsServiceOptions.Value;
             this.initializers = initializers;
             this.modules = modules;
+            this.telemetryProcessorFactories = telemetryProcessorFactories;
             this.telemetryChannel = serviceProvider.GetService<ITelemetryChannel>();
         }
 
@@ -43,6 +47,15 @@ namespace Microsoft.Extensions.DependencyInjection
             if (this.applicationInsightsServiceOptions.InstrumentationKey != null)
             {
                 configuration.InstrumentationKey = this.applicationInsightsServiceOptions.InstrumentationKey;
+            }
+
+            if (this.telemetryProcessorFactories.Count() > 0)
+            {
+                foreach (Func<ITelemetryProcessor, ITelemetryProcessor> processorFactory in this.telemetryProcessorFactories)
+                {
+                    configuration.TelemetryProcessorChainBuilder.Use(processorFactory);
+                }
+                configuration.TelemetryProcessorChainBuilder.Build();
             }
 
             this.AddTelemetryChannelAndProcessorsForFullFramework(configuration);

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 configuration.InstrumentationKey = this.applicationInsightsServiceOptions.InstrumentationKey;
             }
 
-            if (this.telemetryProcessorFactories.Count() > 0)
+            if (this.telemetryProcessorFactories.Any())
             {
                 foreach (Func<ITelemetryProcessor, ITelemetryProcessor> processorFactory in this.telemetryProcessorFactories)
                 {

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -343,6 +343,19 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.True(dependencyModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Count > 0);
             }
 
+            [Fact]
+            public static void RegistersTelemetryConfigurationFactoryMethodThatPopulatesItWithTelemetryProcessorFactoriesFromContainer()
+            {
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                services.AddSingleton<Func<ITelemetryProcessor, ITelemetryProcessor>>((next) => new FakeTelemetryProcessor(next));
+
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
+
+                IServiceProvider serviceProvider = services.BuildServiceProvider();
+                var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
+                Assert.Contains(telemetryConfiguration.TelemetryProcessors, (processor) => processor is FakeTelemetryProcessor);
+            }
+
 #if NET451
             [Fact]
             public static void AddsAddaptiveSamplingServiceToTheConfigurationInFullFrameworkByDefault()

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessor.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessor.cs
@@ -1,0 +1,26 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests
+{
+    using System;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    internal class FakeTelemetryProcessor : ITelemetryProcessor
+    {
+        private readonly ITelemetryProcessor next;
+
+        public FakeTelemetryProcessor(ITelemetryProcessor next)
+        {
+            if (next == null)
+            {
+                throw new ArgumentNullException(nameof(next));
+            }
+
+            this.next = next;
+        }
+
+        public void Process(ITelemetry item)
+        {
+            this.next.Process(item);
+        }
+    }
+}


### PR DESCRIPTION
This is necessary to complete exception snapshotting work for .NET Core and overall a good addition, filling a gap in programmatic initialization capabilities of AI SDK.