### PR TITLE
Telemetry processors are initialized if they implement ITelemetryModule

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -81,6 +81,15 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 module.Initialize(configuration);
             }
+
+            foreach (ITelemetryProcessor processor in configuration.TelemetryProcessors)
+            {
+                ITelemetryModule module = processor as ITelemetryModule;
+                if (module != null)
+                {
+                    module.Initialize(configuration);
+                }
+            }
         }
 
         private void AddTelemetryChannelAndProcessorsForFullFramework(TelemetryConfiguration configuration)

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
                 FakeTelemetryProcessor telemetryProcessor = telemetryConfiguration.TelemetryProcessors.OfType<FakeTelemetryProcessor>().FirstOrDefault();
                 Assert.NotNull(telemetryProcessor);
-                Assert.True(telemetryProcessor.Initialized);
+                Assert.True(telemetryProcessor.IsInitialized);
             }
 
 #if NET451

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -353,7 +353,9 @@ namespace Microsoft.Extensions.DependencyInjection.Test
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
-                Assert.Contains(telemetryConfiguration.TelemetryProcessors, (processor) => processor is FakeTelemetryProcessor);
+                FakeTelemetryProcessor telemetryProcessor = telemetryConfiguration.TelemetryProcessors.OfType<FakeTelemetryProcessor>().FirstOrDefault();
+                Assert.NotNull(telemetryProcessor);
+                Assert.True(telemetryProcessor.Initialized);
             }
 
 #if NET451

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessor.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessor.cs
@@ -16,14 +16,14 @@
             }
 
             this.next = next;
-            this.Initialized = false;
+            this.IsInitialized = false;
         }
 
-        public bool Initialized { get; private set; }
+        public bool IsInitialized { get; private set; }
 
         public void Initialize(TelemetryConfiguration configuration)
         {
-            this.Initialized = true;
+            this.IsInitialized = true;
         }
 
         public void Process(ITelemetry item)

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessor.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessor.cs
@@ -4,7 +4,7 @@
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
 
-    internal class FakeTelemetryProcessor : ITelemetryProcessor
+    internal class FakeTelemetryProcessor : ITelemetryProcessor, ITelemetryModule
     {
         private readonly ITelemetryProcessor next;
 
@@ -16,6 +16,14 @@
             }
 
             this.next = next;
+            this.Initialized = false;
+        }
+
+        public bool Initialized { get; private set; }
+
+        public void Initialize(TelemetryConfiguration configuration)
+        {
+            this.Initialized = true;
         }
 
         public void Process(ITelemetry item)


### PR DESCRIPTION
This change is required to unblock exception snapshotting on .NET Core, for more info see issue https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/447