### PR TITLE
When constructing ConfigurationBuilder, include environment...

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DefaultApplicationInsightsServiceConfigureOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DefaultApplicationInsightsServiceConfigureOptions.cs
@@ -29,6 +29,7 @@
             var configBuilder = new ConfigurationBuilder()
                 .SetBasePath(this.hostingEnvironment.ContentRootPath)
                 .AddJsonFile("appsettings.json", true)
+                .AddJsonFile($"appsettings.{hostingEnvironment.EnvironmentName}.json", true)
                 .AddEnvironmentVariables();
             ApplicationInsightsExtensions.AddTelemetryConfiguration(configBuilder.Build(), options);
 


### PR DESCRIPTION
 appsettings file. This fixes IWebHostBuilder.UseApplicationInsights not using environment specific instrumentation key