### PR TITLE
Fixed key not present error.

### DIFF
--- a/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
+++ b/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
@@ -58,12 +58,7 @@
             }
 
             var telemetries = server.BackChannel.Buffer;
-#if NET451
-            Assert.Contains(telemetries.OfType<DependencyTelemetry>(), t => t.Name == "/Mixed");
-#else
             Assert.Contains(telemetries.OfType<DependencyTelemetry>(), t => t.Name == "GET /Mixed");
-#endif
-
             Assert.True(telemetries.Count >= 4);
             Assert.Contains(telemetries.OfType<RequestTelemetry>(), t => t.Name == "GET /Mixed");
             Assert.Contains(telemetries.OfType<EventTelemetry>(), t => t.Name == "GetContact");

--- a/test/FunctionalTestUtils/TelemetryTestsBase.cs
+++ b/test/FunctionalTestUtils/TelemetryTestsBase.cs
@@ -85,11 +85,7 @@
             DependencyTelemetry expected = new DependencyTelemetry();
             expected.ResultCode = "200";
             expected.Success = true;
-#if NET451
-            expected.Name = requestPath;
-#else
             expected.Name = "GET " + requestPath;
-#endif
 
             InProcessServer server;
             using (server = new InProcessServer(assemblyName, configureHost))

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/RequestTrackingMiddlewareTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/RequestTrackingMiddlewareTest.cs
@@ -93,7 +93,6 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests
             Assert.True(requestTelemetry.Success);
             Assert.Equal(CommonMocks.InstrumentationKey, requestTelemetry.Context.InstrumentationKey);
             Assert.Equal("", requestTelemetry.Source);
-            Assert.Equal("", requestTelemetry.HttpMethod);
             Assert.Equal(CreateUri(HttpRequestScheme, HttpRequestHost), requestTelemetry.Url);
             Assert.NotEmpty(requestTelemetry.Context.GetInternalContext().SdkVersion);
             Assert.Contains(SdkVersionTestUtils.VersionPrefix, requestTelemetry.Context.GetInternalContext().SdkVersion);
@@ -119,7 +118,6 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests
             Assert.True(requestTelemetry.Success);
             Assert.Equal(CommonMocks.InstrumentationKey, requestTelemetry.Context.InstrumentationKey);
             Assert.Equal("", requestTelemetry.Source);
-            Assert.Equal("", requestTelemetry.HttpMethod);
             Assert.Equal(CreateUri(HttpRequestScheme, HttpRequestHost, HttpRequestPath, HttpRequestQueryString), requestTelemetry.Url);
             Assert.NotEmpty(requestTelemetry.Context.GetInternalContext().SdkVersion);
             Assert.Contains(SdkVersionTestUtils.VersionPrefix, requestTelemetry.Context.GetInternalContext().SdkVersion);
@@ -147,7 +145,6 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests
             Assert.False(requestTelemetry.Success);
             Assert.Equal(CommonMocks.InstrumentationKey, requestTelemetry.Context.InstrumentationKey);
             Assert.Equal("", requestTelemetry.Source);
-            Assert.Equal("", requestTelemetry.HttpMethod);
             Assert.Equal(CreateUri(HttpRequestScheme, HttpRequestHost), requestTelemetry.Url);
             Assert.NotEmpty(requestTelemetry.Context.GetInternalContext().SdkVersion);
             Assert.Contains(SdkVersionTestUtils.VersionPrefix, requestTelemetry.Context.GetInternalContext().SdkVersion);


### PR DESCRIPTION
Removed obsolete HttpMethod property references that were throwing exceptions looking up an unused key in the RequestTelemetry internal dictionary.