### PR TITLE
Add alias to AI logger provider

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ProviderAliasAttribute.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ProviderAliasAttribute.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Controls logger provider alias used for configuration
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    internal class ProviderAliasAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProviderAliasAttribute" /> class.
+        /// </summary>
+        public ProviderAliasAttribute(string alias)
+        {
+            Alias = alias;
+        }
+
+        /// <summary>
+        /// Gets an alias that can be used insted full type name during configuration.
+        /// </summary>
+        public string Alias { get; }
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ProviderAliasAttribute.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ProviderAliasAttribute.cs
@@ -1,7 +1,7 @@
-using System;
-
 namespace Microsoft.Extensions.Logging
 {
+    using System;
+
     /// <summary>
     /// Controls logger provider alias used for configuration
     /// </summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ProviderAliasAttribute.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ProviderAliasAttribute.cs
@@ -1,6 +1,3 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
 using System;
 
 namespace Microsoft.Extensions.Logging

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerFactoryExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerFactoryExtensions.cs
@@ -1,8 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-
-namespace Microsoft.Extensions.Logging
+﻿namespace Microsoft.Extensions.Logging
 {
     using System;
     using ApplicationInsights;

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerProvider.cs
@@ -6,6 +6,7 @@
     /// <summary>
     /// <see cref="ILoggerProvider"/> implementation that creates returns instances of <see cref="ApplicationInsightsLogger"/>
     /// </summary>
+    [ProviderAlias("ApplicationInsights")]
     internal class ApplicationInsightsLoggerProvider : ILoggerProvider
     {
         private readonly TelemetryClient telemetryClient;


### PR DESCRIPTION
In logging 2.0 we added ability to configure logging filters in centralized way. To configure filters per logging provider provider full name should be used or alternatively alias specified by `ProviderAliasAttribute`.

`ProviderAliasAttribute` is late bound and is detected by full type name so no reference to new aspnetcore packages is required.

@dnduffy @SergeyKanzhelev 