### PR TITLE
Fix Func injection issue on structuremap and track MVC page names

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs
@@ -78,6 +78,16 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
                         }
                     }
                 }
+                else
+                {
+                    object page;
+                    routeValues.TryGetValue("page", out page);
+                    string pageString = (page == null) ? string.Empty : page.ToString();
+                    if (!string.IsNullOrEmpty(pageString))
+                    {
+                        name = pageString;
+                    }
+                }
             }
 
             return name;

--- a/src/Microsoft.ApplicationInsights.AspNetCore/ITelemetryProcessorFactory.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/ITelemetryProcessorFactory.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore
+{
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    public interface ITelemetryProcessorFactory
+    {
+        ITelemetryProcessor Create(ITelemetryProcessor next);
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNetCore/ITelemetryProcessorFactory.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/ITelemetryProcessorFactory.cs
@@ -3,8 +3,15 @@
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
 
+    /// <summary>
+    /// Represents factory used to create <see cref="ITelemetryProcessor"/> with dependency injection support.
+    /// </summary>
     public interface ITelemetryProcessorFactory
     {
+        /// <summary>
+        /// Returns a <see cref="ITelemetryProcessor"/>,
+        /// given the next <see cref="ITelemetryProcessor"/> in the call chain.
+        /// </summary>
         ITelemetryProcessor Create(ITelemetryProcessor next);
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using System;
     using System.Linq;
     using System.Collections.Generic;
+    using Microsoft.ApplicationInsights.AspNetCore;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
@@ -22,7 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
         private readonly IEnumerable<ITelemetryInitializer> initializers;
         private readonly IEnumerable<ITelemetryModule> modules;
         private readonly ITelemetryChannel telemetryChannel;
-        private readonly IEnumerable<Func<ITelemetryProcessor, ITelemetryProcessor>> telemetryProcessorFactories;
+        private readonly IEnumerable<ITelemetryProcessorFactory> telemetryProcessorFactories;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:TelemetryConfigurationOptionsSetup"/> class.
@@ -32,7 +33,7 @@ namespace Microsoft.Extensions.DependencyInjection
             IOptions<ApplicationInsightsServiceOptions> applicationInsightsServiceOptions,
             IEnumerable<ITelemetryInitializer> initializers,
             IEnumerable<ITelemetryModule> modules,
-            IEnumerable<Func<ITelemetryProcessor, ITelemetryProcessor>> telemetryProcessorFactories)
+            IEnumerable<ITelemetryProcessorFactory> telemetryProcessorFactories)
         {
             this.applicationInsightsServiceOptions = applicationInsightsServiceOptions.Value;
             this.initializers = initializers;
@@ -51,9 +52,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (this.telemetryProcessorFactories.Any())
             {
-                foreach (Func<ITelemetryProcessor, ITelemetryProcessor> processorFactory in this.telemetryProcessorFactories)
+                foreach (ITelemetryProcessorFactory processorFactory in this.telemetryProcessorFactories)
                 {
-                    configuration.TelemetryProcessorChainBuilder.Use(processorFactory);
+                    configuration.TelemetryProcessorChainBuilder.Use(processorFactory.Create);
                 }
                 configuration.TelemetryProcessorChainBuilder.Build();
             }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
     using System.Reflection;
     using Logging;
     using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.AspNetCore;
     using Microsoft.ApplicationInsights.AspNetCore.Logging;
     using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
     using Microsoft.ApplicationInsights.AspNetCore.Tests;
@@ -347,7 +348,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             public static void RegistersTelemetryConfigurationFactoryMethodThatPopulatesItWithTelemetryProcessorFactoriesFromContainer()
             {
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
-                services.AddSingleton<Func<ITelemetryProcessor, ITelemetryProcessor>>((next) => new FakeTelemetryProcessor(next));
+                services.AddSingleton<ITelemetryProcessorFactory>(new MockTelemetryProcessorFactory((next) => new FakeTelemetryProcessor(next)));
 
                 services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
 
@@ -588,6 +589,18 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             public void AddProvider(ILoggerProvider provider)
             {
             }
+        }
+
+        private class MockTelemetryProcessorFactory: ITelemetryProcessorFactory
+        {
+            public Func<ITelemetryProcessor, ITelemetryProcessor> Factory { get; set; }
+
+            public MockTelemetryProcessorFactory(Func<ITelemetryProcessor, ITelemetryProcessor> factory)
+            {
+                this.Factory = factory;
+            }
+
+            public ITelemetryProcessor Create(ITelemetryProcessor next) => Factory(next);
         }
     }
 }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
@@ -117,6 +117,26 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
         }
 
         [Fact]
+        public void InitializeSetsTelemetryOperationNameToPageFromActionContext()
+        {
+            var actionContext = new ActionContext();
+            actionContext.RouteData = new RouteData();
+            actionContext.RouteData.Values.Add("page", "/Index");
+
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
+
+            var telemetryListener = new DiagnosticListener(TestListenerName);
+            var initializer = new MvcDiagnosticsListener();
+            telemetryListener.SubscribeWithAdapter(initializer);
+            telemetryListener.Write("Microsoft.AspNetCore.Mvc.BeforeAction",
+                new { httpContext = contextAccessor.HttpContext, routeData = actionContext.RouteData });
+
+            var telemetry = contextAccessor.HttpContext.Features.Get<RequestTelemetry>();
+
+            Assert.Equal("GET /Index", telemetry.Name);
+        }
+
+        [Fact]
         public void InitializeSetsTelemetryOperationNameToControllerAndActionAndParameterFromActionContext()
         {
             var actionContext = new ActionContext();


### PR DESCRIPTION
Instead of injecting `Func<,>` factory interface is introduced.

OperationName from MVC Razor Page is generated the same way controller/action is makes for simpler code change and consistent behavior.

https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/482
https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/430

@dnduffy 
