### PR TITLE
Build definition modified to build tests all the time. 

### DIFF
--- a/dirs.proj
+++ b/dirs.proj
@@ -12,10 +12,10 @@
     <ItemGroup>
         <!--<Solution Include="src\Microsoft.ApplicationInsights.AspNetCore\Microsoft.ApplicationInsights.AspNetCore.xproj" />-->
         <!-- Tests -->
-        <TestProject Condition="$(RunTests) != '' And $(RunTests)" Include="test\Microsoft.ApplicationInsights.AspNetCore.Tests\ " />
-        <TestProject Condition="$(RunTests) != '' And $(RunTests)" Include="test\WebApiShimFw46.FunctionalTests\ " />
-        <TestProject Condition="$(RunTests) != '' And $(RunTests)" Include="test\EmptyApp.FunctionalTests\ " />
-        <TestProject Condition="$(RunTests) != '' And $(RunTests)" Include="test\MVCFramework45.FunctionalTests\ " />
+        <TestProject Include="test\Microsoft.ApplicationInsights.AspNetCore.Tests\ " />
+        <TestProject Include="test\WebApiShimFw46.FunctionalTests\ " />
+        <TestProject Include="test\EmptyApp.FunctionalTests\ " />
+        <TestProject Include="test\MVCFramework45.FunctionalTests\ " />
     </ItemGroup>
 
     <UsingTask TaskName="DownloadFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">

--- a/dirs.proj
+++ b/dirs.proj
@@ -172,7 +172,7 @@
         <Exec Command='"$(CliToolsPath)\dotnet.exe" --version' />        
         <Exec Command='"nuget.exe" restore' ContinueOnError="ErrorAndStop" />
         <Exec Command='"$(CliToolsPath)\dotnet.exe" build $(ProjectToBuild) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
-        <Exec Condition="$(RunTests) != '' And $(RunTests)" Command='"$(CliToolsPath)\dotnet.exe" build %(TestProject.Identity) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
+        <Exec Command='"$(CliToolsPath)\dotnet.exe" build %(TestProject.Identity) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
         <Message Condition="$(RunTests) != '' And $(RunTests)" Importance="high" Text="Running tests..."></Message>
         <Exec Condition="$(RunTests) != '' And $(RunTests)" Command='"$(CliToolsPath)\dotnet.exe" test' WorkingDirectory='%(TestProject.Identity)' ContinueOnError="ErrorAndStop" />
     </Target>


### PR DESCRIPTION
Build definition modified to build tests all the time. The flag runtests only determine whether the tests are run or not.

This is required to split the build and test steps into separate tasks in build lab,