### PR TITLE
Version and some minor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 2.2.0-beta1
+
+- Project is upgraded to work with Visual Studio 2017. Also projects are modified to use csproj instead of project.json.
+
 ## Version 2.1.1
 
 - [Address the issue where DependencyCollection breaks Azure Storage Emulator calls](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/488)

--- a/dirs.proj
+++ b/dirs.proj
@@ -172,10 +172,13 @@
         <Exec Command='"$(CliToolsPath)\dotnet.exe" --version' />        
         <Exec Command='"nuget.exe" restore' ContinueOnError="ErrorAndStop" />
         <Exec Command='"$(CliToolsPath)\dotnet.exe" build $(ProjectToBuild) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
-        <Exec Command='"$(CliToolsPath)\dotnet.exe" build %(TestProject.Identity) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
-        <Message Condition="$(RunTests) != '' And $(RunTests)" Importance="high" Text="Running tests..."></Message>
-        <Exec Condition="$(RunTests) != '' And $(RunTests)" Command='"$(CliToolsPath)\dotnet.exe" test' WorkingDirectory='%(TestProject.Identity)' ContinueOnError="ErrorAndStop" />
+        <Exec Command='"$(CliToolsPath)\dotnet.exe" build %(TestProject.Identity) -c $(Configuration)' ContinueOnError="ErrorAndStop" />        
     </Target>
+	
+	<Target Name="Test" AfterTargets="Build" DependsOnTargets="Build">
+		<Message Condition="$(RunTests) != '' And $(RunTests)" Importance="high" Text="Running tests..."></Message>
+        <Exec Condition="$(RunTests) != '' And $(RunTests)" Command='"$(CliToolsPath)\dotnet.exe" test' WorkingDirectory='%(TestProject.Identity)' ContinueOnError="ErrorAndStop" />
+	</Target>
 
     <Target Name="Clean">
         <RemoveDir Directories="$(BinRoot)\$(Configuration)" />
@@ -184,7 +187,7 @@
         <Delete Files="$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-dev-win-x64.1.0.4.zip" />
     </Target>
 
-    <Target Name="AfterBuild" AfterTargets="Build" DependsOnTargets="Build">
+    <Target Name="AfterBuild" AfterTargets="Test" DependsOnTargets="Test">
         <ItemGroup>
             <FilesToSign Include="**\Microsoft.ApplicationInsights.AspNetCore.dll">
                 <Authenticode Condition="'%(FilesToSign.Authenticode)' == ''">Microsoft</Authenticode>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -4,7 +4,7 @@
     <Description>Application Insights for ASP.NET Core web applications. See https://azure.microsoft.com/documentation/articles/app-insights-asp-net-five/ for more information. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>
     <Copyright>Copyright © Microsoft. All Rights Reserved.</Copyright>
     <AssemblyTitle>Application Insights for ASP.NET Core Web Applications</AssemblyTitle>
-    <VersionPrefix>2.1.1</VersionPrefix>
+    <VersionPrefix>2.2.0-beta1</VersionPrefix>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
     <DelaySign>true</DelaySign>

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 
-namespace SampleWebAppIntegration.FunctionalTest
+namespace MVCFramework45.FunctionalTests.FunctionalTest
 {
     using System;
     using System.Collections.Generic;

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/ExceptionTelemetryMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/ExceptionTelemetryMvcTests.cs
@@ -1,7 +1,7 @@
 ﻿using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
-namespace SampleWebAppIntegration.FunctionalTest
+namespace MVCFramework45.FunctionalTests.FunctionalTest
 {
     using System;
     using FunctionalTestUtils;

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 
-namespace SampleWebAppIntegration.FunctionalTest
+namespace MVCFramework45.FunctionalTests.FunctionalTest
 {
     using System.Linq;
     using System.Net.Http;

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
@@ -1,4 +1,4 @@
-﻿namespace SampleWebAppIntegration.FunctionalTest
+﻿namespace MVCFramework45.FunctionalTests.FunctionalTest
 {
     using FunctionalTestUtils;
     using Xunit;

--- a/test/WebApiShimFw46.FunctionalTests/FunctionalTest/ExceptionTelemetryWebApiTests.cs
+++ b/test/WebApiShimFw46.FunctionalTests/FunctionalTest/ExceptionTelemetryWebApiTests.cs
@@ -1,4 +1,4 @@
-﻿namespace SampleWebAppIntegration.FunctionalTest
+﻿namespace WebApiShimFw46.FunctionalTests.FunctionalTest
 {
     using System;
     using FunctionalTestUtils;

--- a/test/WebApiShimFw46.FunctionalTests/FunctionalTest/RequestTelemetryWebApiTests.cs
+++ b/test/WebApiShimFw46.FunctionalTests/FunctionalTest/RequestTelemetryWebApiTests.cs
@@ -1,4 +1,4 @@
-﻿namespace SampleWebAppIntegration.FunctionalTest
+﻿namespace WebApiShimFw46.FunctionalTests.FunctionalTest
 {
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;

--- a/test/WebApiShimFw46.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
+++ b/test/WebApiShimFw46.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
@@ -1,7 +1,7 @@
 ﻿using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
-namespace SampleWebAppIntegration.FunctionalTest
+namespace WebApiShimFw46.FunctionalTests.FunctionalTest
 {
     using FunctionalTestUtils;
 


### PR DESCRIPTION
Version updated to 2.2.0-beta1
Minor renaming of tests namespaces for easier visibility in VS Test Explorer
dirs.proj - test is separated into own build target which runs after build for ease of understanding build logs.