### PR TITLE
Add net46 target to source, and replace testing with net46 instead of net451

### DIFF
--- a/dirs.proj
+++ b/dirs.proj
@@ -79,7 +79,7 @@
                                     directoryInfo.Create();
                                 }
 
-                                Log.LogMessage("Extracting entry to path:{0}", path);
+                                //Log.LogMessage("Extracting entry to path:{0}", path);
                                 entry.ExtractToFile(path, Overwrite);
                             }
                         }

--- a/dirs.proj
+++ b/dirs.proj
@@ -75,7 +75,7 @@
                                 DirectoryInfo directoryInfo = new DirectoryInfo(fileInfo.DirectoryName);
                                 if (false == directoryInfo.Exists)
                                 {
-                                    Log.LogMessage ("Creating directory for archive entry, path:{0}", directoryInfo.FullName);
+                                    //Log.LogMessage ("Creating directory for archive entry, path:{0}", directoryInfo.FullName);
                                     directoryInfo.Create();
                                 }
 
@@ -170,7 +170,7 @@
     
     <Target Name="Build" DependsOnTargets="CheckBuildParameters;DownloadCLI">
         <Exec Command='"$(CliToolsPath)\dotnet.exe" --version' />        
-        <Exec Command='"nuget.exe" restore' ContinueOnError="ErrorAndStop" />
+        <Exec Command='"nuget.exe" restore -Verbosity quiet' ContinueOnError="ErrorAndStop" />
         <Exec Command='"$(CliToolsPath)\dotnet.exe" build $(ProjectToBuild) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
         <Exec Command='"$(CliToolsPath)\dotnet.exe" build %(TestProject.Identity) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
         <Message Condition="$(RunTests) != '' And $(RunTests)" Importance="high" Text="Running tests..."></Message>

--- a/dirs.proj
+++ b/dirs.proj
@@ -170,7 +170,7 @@
     
     <Target Name="Build" DependsOnTargets="CheckBuildParameters;DownloadCLI">
         <Exec Command='"$(CliToolsPath)\dotnet.exe" --version' />        
-        <Exec Command='"nuget.exe" restore -Verbosity quiet' ContinueOnError="ErrorAndStop" />
+        <Exec Command='"nuget.exe" restore' ContinueOnError="ErrorAndStop" />
         <Exec Command='"$(CliToolsPath)\dotnet.exe" build $(ProjectToBuild) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
         <Exec Command='"$(CliToolsPath)\dotnet.exe" build %(TestProject.Identity) -c $(Configuration)' ContinueOnError="ErrorAndStop" />
         <Message Condition="$(RunTests) != '' And $(RunTests)" Importance="high" Text="Running tests..."></Message>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/ContextData.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/ContextData.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
 {
-#if NET451
+#if NET451 || NET46
     using System.Runtime.Remoting.Messaging;
     using System.Runtime.Remoting;
 #else
@@ -12,7 +12,7 @@
     /// <typeparam name="T">The type of the ambient data. </typeparam>
     internal class ContextData<T>
     {
-#if NET451
+#if NET451 || NET46
         private static readonly string Key = typeof(ContextData<T>).FullName;
 
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/CorrelationIdLookupHelper.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/CorrelationIdLookupHelper.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
     using Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Extensibility;
 
-#if NET451
+#if NET451 || NET46
     using System.IO;
     using System.Net;
 #else
@@ -195,7 +195,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
                 }
 
                 string result = null;
-#if NET451
+#if NET451 || NET46
                 WebRequest request = WebRequest.Create(appIdEndpoint);
                 request.Method = "GET";
                 using (HttpWebResponse response = (HttpWebResponse)await request.GetResponseAsync().ConfigureAwait(false))

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Options;
 
-#if NET451
+#if NET451 || NET46
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
 #endif
 
@@ -152,7 +152,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     return module;
                 });
 
-#if NET451
+#if NET451 || NET46
                 services.AddSingleton<ITelemetryModule, PerformanceCollectorModule>();
 #endif
                 services.AddSingleton<TelemetryConfiguration>(provider => provider.GetService<IOptions<TelemetryConfiguration>>().Value);

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
-#if NET451
+#if NET451 || NET46
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 #endif
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private void AddTelemetryChannelAndProcessorsForFullFramework(TelemetryConfiguration configuration)
         {
-#if NET451
+#if NET451 || NET46
             // Adding Server Telemetry Channel if services doesn't have an existing channel
             configuration.TelemetryChannel = this.telemetryChannel ?? new ServerTelemetryChannel();
             if (configuration.TelemetryChannel is ServerTelemetryChannel)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Application Insights for ASP.NET Core Web Applications</AssemblyTitle>
     <VersionPrefix>2.1.1</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;net46;netstandard1.6</TargetFrameworks>
     <DelaySign>true</DelaySign>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore</AssemblyName>
@@ -69,7 +69,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.4.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.4.0" />

--- a/src/Microsoft.ApplicationInsights.AspNetCore/SdkVersionUtils.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/SdkVersionUtils.cs
@@ -5,7 +5,7 @@
 
     internal class SdkVersionUtils
     {
-#if NET451
+#if NET451 || NET46
         public const string VersionPrefix = "aspnet5f:";
 #else
         public const string VersionPrefix = "aspnet5c:";

--- a/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests.csproj
+++ b/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net451' ">win7-x86</RuntimeIdentifier>
+    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
     <DelaySign>true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>EmptyApp.FunctionalTests</AssemblyName>
@@ -22,12 +22,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.0.2" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/test/EmptyApp.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
+++ b/test/EmptyApp.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
@@ -18,7 +18,7 @@
         [Fact]
         public void TestIfPerformanceCountersAreCollected()
         {
-#if NET451
+#if NET451 || NET46
             ValidatePerformanceCountersAreCollected(assemblyName);
 #endif
         }

--- a/test/FunctionalTestUtils/FunctionalTestUtils.csproj
+++ b/test/FunctionalTestUtils/FunctionalTestUtils.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.2</VersionPrefix>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <DelaySign>true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>FunctionalTestUtils</AssemblyName>
@@ -20,10 +20,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.3" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/test/FunctionalTestUtils/TelemetryTestsBase.cs
+++ b/test/FunctionalTestUtils/TelemetryTestsBase.cs
@@ -13,7 +13,7 @@
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.DependencyInjection;
     using Xunit;
-#if NET451
+#if NET451 || NET46
     using System.Net;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
     using Microsoft.ApplicationInsights.Extensibility;
@@ -119,7 +119,7 @@
 #endif
         }
 
-#if NET451
+#if NET451 || NET46
         public void ValidatePerformanceCountersAreCollected(string assemblyName, Func<IWebHostBuilder, IWebHostBuilder> configureHost = null)
         {
             using (var server = new InProcessServer(assemblyName, configureHost))

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/CorrelationMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/CorrelationMvcTests.cs
@@ -14,7 +14,7 @@
         [Fact]
         public void CorrelationInfoIsPropagatedToDependendedService()
         {
-#if !NET451 // Correlation is not supported in NET451. It works with NET46 and .Net core.
+#if netcoreapp1_0 // Correlation works on .Net core.
             InProcessServer server;
 
             using (server = new InProcessServer(assemblyName, InProcessServer.UseApplicationInsights))

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
@@ -22,7 +22,7 @@ namespace SampleWebAppIntegration.FunctionalTest
         [Fact]
         public void CorrelationInfoIsNotAddedToRequestHeaderIfUserAddDomainToExcludedList()
         {
-#if !NET451 // Correlation is not supported in NET451. It works with NET46 and .Net core.
+#if netcoreapp1_0 // Correlation is supported on .Net core.
             InProcessServer server;
 
             using (server = new InProcessServer(assemblyName, InProcessServer.UseApplicationInsights))

--- a/test/MVCFramework45.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
+++ b/test/MVCFramework45.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
@@ -18,7 +18,7 @@
         [Fact]
         public void TestIfPerformanceCountersAreCollected()
         {
-#if NET451
+#if NET451 || NET46
             ValidatePerformanceCountersAreCollected(assemblyName, InProcessServer.UseApplicationInsights);
 #endif
         }

--- a/test/MVCFramework45.FunctionalTests/MVCFramework45.FunctionalTests.csproj
+++ b/test/MVCFramework45.FunctionalTests/MVCFramework45.FunctionalTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net451' ">win7-x86</RuntimeIdentifier>
+    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
     <DelaySign>true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>MVCFramework45.FunctionalTests</AssemblyName>
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.0.2" />
@@ -60,10 +60,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.2" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Options;
 
-#if NET451
+#if NET451 || NET46
     using ApplicationInsights.Extensibility.PerfCounterCollector;
     using ApplicationInsights.WindowsServer.TelemetryChannel;
     using ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
@@ -329,7 +329,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
 
-#if NET451
+#if NET451 || NET46
                 Assert.Equal(2, modules.Count());
                 var perfCounterModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(PerformanceCollectorModule));
                 Assert.NotNull(perfCounterModule);
@@ -359,7 +359,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.True(telemetryProcessor.IsInitialized);
             }
 
-#if NET451
+#if NET451 || NET46
             [Fact]
             public static void AddsAddaptiveSamplingServiceToTheConfigurationInFullFrameworkByDefault()
             {

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
     <DelaySign>true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore.Tests</AssemblyName>
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.0.2" />
@@ -36,10 +36,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/SdkVersionTestUtils.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/SdkVersionTestUtils.cs
@@ -2,7 +2,7 @@
 {
     public class SdkVersionTestUtils
     {
-#if NET451
+#if NET451 || NET46
         public const string VersionPrefix = "aspnet5f:";
 #else
         public const string VersionPrefix = "aspnet5c:";

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializerTests.cs
@@ -54,7 +54,7 @@
             
             string hostName = Dns.GetHostName();
 
-#if NET451
+#if NET451 || NET46
             string domainName = IPGlobalProperties.GetIPGlobalProperties().DomainName;
             if (hostName.EndsWith(domainName, StringComparison.OrdinalIgnoreCase) == false)
             {

--- a/test/WebApiShimFw46.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
+++ b/test/WebApiShimFw46.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
@@ -20,7 +20,7 @@ namespace SampleWebAppIntegration.FunctionalTest
         [Fact]
         public void TestIfPerformanceCountersAreCollected()
         {
-#if NET451
+#if NET451 || NET46
             ValidatePerformanceCountersAreCollected(assemblyName);
 #endif
         }

--- a/test/WebApiShimFw46.FunctionalTests/WebApiShimFw46.FunctionalTests.csproj
+++ b/test/WebApiShimFw46.FunctionalTests/WebApiShimFw46.FunctionalTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net451' ">win7-x86</RuntimeIdentifier>
+    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
     <DelaySign>true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>WebApiShimFw46.FunctionalTests</AssemblyName>
@@ -34,16 +34,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit" Version="2.2.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
Added a new target net46 for the aspnet core project, and replaced all testing to target net46 instead of net451. The motivation behind this is to run tests using stable version of xunit, which no longer support net451.