### PR TITLE
Add an AddApplicationInsightsTelemetryProcessor extension method

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -181,6 +181,19 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Adds an Application Insights Telemetry Processor into a service collection via a <see cref="ITelemetryProcessorFactory"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of the telemetry processor to add.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> instance.</param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/>.
+        /// </returns>
+        public static IServiceCollection AddApplicationInsightsTelemetryProcessor<T>(this IServiceCollection services) where T : ITelemetryProcessor
+        {
+            return services.AddSingleton<ITelemetryProcessorFactory>(new TelemetryProcessorFactory<T>());
+        }
+
+        /// <summary>
         /// Adds Application Insight specific configuration properties to <see cref="IConfigurationBuilder"/>.
         /// </summary>
         /// <param name="configurationSourceRoot">The <see cref="IConfigurationBuilder"/> instance.</param>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>
         public static IServiceCollection AddApplicationInsightsTelemetryProcessor<T>(this IServiceCollection services) where T : ITelemetryProcessor
         {
-            return services.AddSingleton<ITelemetryProcessorFactory>(new TelemetryProcessorFactory<T>());
+            return services.AddSingleton<ITelemetryProcessorFactory>(serviceProvider => new TelemetryProcessorFactory<T>(serviceProvider));
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     using System;
     using System.Collections.Generic;
+    using System.Reflection;
     using AspNetCore.Builder;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.AspNetCore;
@@ -190,7 +191,32 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>
         public static IServiceCollection AddApplicationInsightsTelemetryProcessor<T>(this IServiceCollection services) where T : ITelemetryProcessor
         {
-            return services.AddSingleton<ITelemetryProcessorFactory>(serviceProvider => new TelemetryProcessorFactory<T>(serviceProvider));
+            return services.AddSingleton<ITelemetryProcessorFactory>(serviceProvider => new TelemetryProcessorFactory(serviceProvider, typeof(T)));
+        }
+
+        /// <summary>
+        /// Adds an Application Insights Telemetry Processor into a service collection via a <see cref="ITelemetryProcessorFactory"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> instance.</param>
+        /// <param name="telemetryProcessorType">Type of the telemetry processor to add.</param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">The <paramref name="telemetryProcessorType"/> argument is null.</exception>
+        /// <exception cref="ArgumentException">The <paramref name="telemetryProcessorType"/> type does not implement <see cref="ITelemetryProcessor"/>.</exception>
+        public static IServiceCollection AddApplicationInsightsTelemetryProcessor(this IServiceCollection services, Type telemetryProcessorType)
+        {
+            if (telemetryProcessorType == null)
+            {
+                throw new ArgumentNullException(nameof(telemetryProcessorType));
+            }
+
+            if (!telemetryProcessorType.GetTypeInfo().ImplementedInterfaces.Contains(typeof(ITelemetryProcessor)))
+            {
+                throw new ArgumentException(nameof(telemetryProcessorType));
+            }
+
+            return services.AddSingleton<ITelemetryProcessorFactory>(serviceProvider => new TelemetryProcessorFactory(serviceProvider, telemetryProcessorType));
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryProcessorFactory.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryProcessorFactory.cs
@@ -7,18 +7,20 @@
     /// <summary>
     /// A generic factory for telemetry processors of a given type.
     /// </summary>
-    /// <typeparam name="T">The type of telemetry processor created by this factory.</typeparam>
-    internal class TelemetryProcessorFactory<T> : ITelemetryProcessorFactory where T : ITelemetryProcessor
+    internal class TelemetryProcessorFactory : ITelemetryProcessorFactory
     {
         private readonly IServiceProvider serviceProvider;
+        private readonly Type telemetryProcessorType;
 
         /// <summary>
         /// Constructs an instance of the factory.
         /// </summary>
         /// <param name="serviceProvider">The service provider.</param>
-        public TelemetryProcessorFactory(IServiceProvider serviceProvider)
+        /// <param name="telemetryProcessorType">The type of telemetry processor to create.</param>
+        public TelemetryProcessorFactory(IServiceProvider serviceProvider, Type telemetryProcessorType)
         {
             this.serviceProvider = serviceProvider;
+            this.telemetryProcessorType = telemetryProcessorType;
         }
 
         /// <summary>
@@ -28,7 +30,7 @@
         /// </summary>
         public ITelemetryProcessor Create(ITelemetryProcessor next)
         {
-            return ActivatorUtilities.CreateInstance<T>(serviceProvider, next);
+            return (ITelemetryProcessor)ActivatorUtilities.CreateInstance(this.serviceProvider, this.telemetryProcessorType, next);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryProcessorFactory.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryProcessorFactory.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore
+{
+    using System;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    /// <summary>
+    /// A generic factory for telemetry processors of a given type.
+    /// </summary>
+    /// <typeparam name="T">The type of telemetry processor created by this factory.</typeparam>
+    internal class TelemetryProcessorFactory<T> : ITelemetryProcessorFactory where T : ITelemetryProcessor
+    {
+        /// <summary>
+        /// Creates an instance of the telemetry processor, passing the
+        /// next <see cref="ITelemetryProcessor"/> in the call chain to
+        /// its constructor.
+        /// </summary>
+        public ITelemetryProcessor Create(ITelemetryProcessor next)
+        {
+            return (ITelemetryProcessor)Activator.CreateInstance(typeof(T), args: next);
+        }
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryProcessorFactory.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryProcessorFactory.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
     /// A generic factory for telemetry processors of a given type.
@@ -9,6 +10,17 @@
     /// <typeparam name="T">The type of telemetry processor created by this factory.</typeparam>
     internal class TelemetryProcessorFactory<T> : ITelemetryProcessorFactory where T : ITelemetryProcessor
     {
+        private readonly IServiceProvider serviceProvider;
+
+        /// <summary>
+        /// Constructs an instance of the factory.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider.</param>
+        public TelemetryProcessorFactory(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+        }
+
         /// <summary>
         /// Creates an instance of the telemetry processor, passing the
         /// next <see cref="ITelemetryProcessor"/> in the call chain to
@@ -16,7 +28,7 @@
         /// </summary>
         public ITelemetryProcessor Create(ITelemetryProcessor next)
         {
-            return (ITelemetryProcessor)Activator.CreateInstance(typeof(T), args: next);
+            return ActivatorUtilities.CreateInstance<T>(serviceProvider, next);
         }
     }
 }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -374,6 +374,19 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.Throws<ArgumentException>(() => services.AddApplicationInsightsTelemetryProcessor(typeof(ITelemetryProcessor)));
             }
 
+            [Fact]
+            public static void AddApplicationInsightsTelemetryProcessorWithImportingConstructor()
+            {
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                services.AddApplicationInsightsTelemetryProcessor<FakeTelemetryProcessorWithImportingConstructor>();
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
+                IServiceProvider serviceProvider = services.BuildServiceProvider();
+                var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
+                FakeTelemetryProcessorWithImportingConstructor telemetryProcessor = telemetryConfiguration.TelemetryProcessors.OfType<FakeTelemetryProcessorWithImportingConstructor>().FirstOrDefault();
+                Assert.NotNull(telemetryProcessor);
+                Assert.Same(serviceProvider.GetService<IHostingEnvironment>(), telemetryProcessor.HostingEnvironment);
+            }
+
 #if NET451 || NET46
             [Fact]
             public static void AddsAddaptiveSamplingServiceToTheConfigurationInFullFrameworkByDefault()

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             public static void RegistersTelemetryConfigurationFactoryMethodThatPopulatesItWithTelemetryProcessorFactoriesFromContainer()
             {
                 var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
-                services.AddSingleton<ITelemetryProcessorFactory>(new MockTelemetryProcessorFactory((next) => new FakeTelemetryProcessor(next)));
+                services.AddApplicationInsightsTelemetryProcessor<FakeTelemetryProcessor>();
 
                 services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
 
@@ -589,18 +589,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             public void AddProvider(ILoggerProvider provider)
             {
             }
-        }
-
-        private class MockTelemetryProcessorFactory: ITelemetryProcessorFactory
-        {
-            public Func<ITelemetryProcessor, ITelemetryProcessor> Factory { get; set; }
-
-            public MockTelemetryProcessorFactory(Func<ITelemetryProcessor, ITelemetryProcessor> factory)
-            {
-                this.Factory = factory;
-            }
-
-            public ITelemetryProcessor Create(ITelemetryProcessor next) => Factory(next);
         }
     }
 }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -359,6 +359,21 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.True(telemetryProcessor.IsInitialized);
             }
 
+            [Fact]
+            public static void AddApplicationInsightsTelemetryProcessorWithNullTelemetryProcessorTypeThrows()
+            {
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                Assert.Throws<ArgumentNullException>(() => services.AddApplicationInsightsTelemetryProcessor(null));
+            }
+
+            [Fact]
+            public static void AddApplicationInsightsTelemetryProcessorWithNonTelemetryProcessorTypeThrows()
+            {
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                Assert.Throws<ArgumentException>(() => services.AddApplicationInsightsTelemetryProcessor(typeof(string)));
+                Assert.Throws<ArgumentException>(() => services.AddApplicationInsightsTelemetryProcessor(typeof(ITelemetryProcessor)));
+            }
+
 #if NET451
             [Fact]
             public static void AddsAddaptiveSamplingServiceToTheConfigurationInFullFrameworkByDefault()

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessorWithImportingConstructor.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessorWithImportingConstructor.cs
@@ -1,0 +1,30 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests
+{
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.AspNetCore.Hosting;
+
+    internal class FakeTelemetryProcessorWithImportingConstructor : ITelemetryProcessor
+    {
+        private readonly ITelemetryProcessor nextProcessor;
+
+        public IHostingEnvironment HostingEnvironment { get; }
+
+        /// <summary>
+        /// Constructs an instance of the telemetry processor.
+        /// This constructor is designed to be called from a DI framework.
+        /// </summary>
+        /// <param name="next">The next procesor in the chain.</param>
+        /// <param name="hostingEnvironment">The hosting environment. This parameter will be injected by the DI framework.</param>
+        public FakeTelemetryProcessorWithImportingConstructor(ITelemetryProcessor next, IHostingEnvironment hostingEnvironment)
+        {
+            this.nextProcessor = next;
+            this.HostingEnvironment = hostingEnvironment;
+        }
+
+        public void Process(ITelemetry item)
+        {
+            nextProcessor.Process(item);
+        }
+    }
+}


### PR DESCRIPTION
We changed the way TelemetryProcessors are injected in #489 
This makes it more cumbersome for callers, since they have to define a `TelemetryProcessorFactory` class instead of just using an inline lambda.

We can help by adding a generic extension method that uses a generic telemetry processor factory.