### PR TITLE
upgrade to the 2.5.0-beta1 and enable Adaptive sampling on all ptatfo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 2.2.0-beta1
 
 - Project is upgraded to work with Visual Studio 2017. Also projects are modified to use csproj instead of project.json.
+- Adaptive sampling enabled for both - full framework and .NET Core applications.
 
 ## Version 2.1.1
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -59,7 +59,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 configuration.TelemetryProcessorChainBuilder.Build();
             }
 
-            this.AddTelemetryChannelAndProcessorsForFullFramework(configuration);
+            this.AddTelemetryChannelAndProcessors(configuration);
+            (configuration.TelemetryChannel as ITelemetryModule)?.Initialize(configuration);
+
+            configuration.TelemetryProcessorChainBuilder.Build();
+
 
             configuration.TelemetryChannel = this.telemetryChannel ?? configuration.TelemetryChannel;
 
@@ -91,15 +95,13 @@ namespace Microsoft.Extensions.DependencyInjection
                     module.Initialize(configuration);
                 }
             }
-
-            (configuration.TelemetryChannel as ITelemetryModule)?.Initialize(configuration);
-
-            configuration.TelemetryProcessorChainBuilder.Build();
         }
 
-        private void AddTelemetryChannelAndProcessorsForFullFramework(TelemetryConfiguration configuration)
+        private void AddTelemetryChannelAndProcessors(TelemetryConfiguration configuration)
         {
 #if NET451 || NET46
+            configuration.TelemetryChannel = this.telemetryChannel ?? new ServerTelemetryChannel();
+
             if (configuration.TelemetryChannel is ServerTelemetryChannel)
             {
                 // Enabling Quick Pulse Metric Stream

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -65,14 +65,14 @@
     <PackageReference Include="System.Threading.Tasks.Analyzers" Version="1.2.0-beta2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.0-beta1-build10212" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.5.0-beta1-build00479" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.5.0-beta1-build10212" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.0-beta1-build13120" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.5.0-beta1-build01033" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.5.0-beta1-build13120" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.5.0-beta1-build00479" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.5.0-beta1-build01033" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -65,14 +65,14 @@
     <PackageReference Include="System.Threading.Tasks.Analyzers" Version="1.2.0-beta2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.4.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.0-beta1-build10212" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.5.0-beta1-build00479" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.5.0-beta1-build10212" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.4.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.4.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.5.0-beta1-build00479" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests.csproj
+++ b/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests.csproj
@@ -13,7 +13,9 @@
     <PackageId>EmptyApp.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.1</RuntimeFrameworkVersion>
-	<OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,6 +39,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Generator>SettingsSingleFileGenerator</Generator>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/FunctionalTestUtils/InProcessServer.cs
+++ b/test/FunctionalTestUtils/InProcessServer.cs
@@ -58,6 +58,7 @@
             {
                 builder = configureHost(builder);
             }
+
             this.hostingEngine = builder.Build();
 
             this.hostingEngine.Start();

--- a/test/MVCFramework45.FunctionalTests/MVCFramework45.FunctionalTests.csproj
+++ b/test/MVCFramework45.FunctionalTests/MVCFramework45.FunctionalTests.csproj
@@ -14,9 +14,11 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <UserSecretsId>aspnet-MVCFramework45.FunctionalTests-60cfc765-2dc9-454c-bb34-dc379ed92cd0</UserSecretsId>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.1</RuntimeFrameworkVersion>
-	<OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
-	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
@@ -66,6 +68,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -12,7 +12,9 @@
     <PackageId>Microsoft.ApplicationInsights.AspNetCore.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.1</RuntimeFrameworkVersion>
-	<OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
@@ -49,6 +51,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Generator>SettingsSingleFileGenerator</Generator>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/WebApiShimFw46.FunctionalTests/FunctionalTest/ExceptionTelemetryWebApiTests.cs
+++ b/test/WebApiShimFw46.FunctionalTests/FunctionalTest/ExceptionTelemetryWebApiTests.cs
@@ -4,6 +4,7 @@
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
+    using Microsoft.ApplicationInsights.Extensibility;
 
     public class ExceptionTelemetryWebApiTests : TelemetryTestsBase
     {

--- a/test/WebApiShimFw46.FunctionalTests/WebApiShimFw46.FunctionalTests.csproj
+++ b/test/WebApiShimFw46.FunctionalTests/WebApiShimFw46.FunctionalTests.csproj
@@ -14,7 +14,9 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.1</RuntimeFrameworkVersion>
-	<OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
@@ -46,6 +48,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
…rms. Tests are failing

Using latest version of Application Insights (2.5.0-beta1) exposed the problem with multi-sink. Unit tests failing as the channel cannot be overridden on the DefaultSink.

@karolz-ms do you have ides off the top of your head? Otherwise I'll keep debugging in the end of the day