### PR TITLE
Check appId response code before using content

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/CorrelationIdLookupHelper.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/CorrelationIdLookupHelper.cs
@@ -199,14 +199,21 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
                 WebRequest request = WebRequest.Create(appIdEndpoint);
                 request.Method = "GET";
                 using (HttpWebResponse response = (HttpWebResponse)await request.GetResponseAsync().ConfigureAwait(false))
-                using (StreamReader reader = new StreamReader(response.GetResponseStream()))
                 {
-                    result = await reader.ReadToEndAsync();
+                    if (response.StatusCode == HttpStatusCode.OK)
+                    {
+                        using (StreamReader reader = new StreamReader(response.GetResponseStream()))
+                        {
+                            result = await reader.ReadToEndAsync();
+                        }
+                    }
                 }
 #else
                 using (HttpClient client = new HttpClient())
                 {
-                    result = await client.GetStringAsync(appIdEndpoint).ConfigureAwait(false);
+                    var resultMessage = await client.GetAsync(appIdEndpoint).ConfigureAwait(false);
+                    if (resultMessage.IsSuccessStatusCode)
+                        result = await resultMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
                 }
 #endif
                 return result;


### PR DESCRIPTION
This pullrequest is to solve an issue where appId detection is incorrectly using a non-200 http response as appId and is breaking applications.

Issue: #524 