### PR TITLE
Remove signing from test projects

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,14 @@
-Fix issue # .
+Fix Issue # .
+<Short description of the fix.>
 
-Short description of the fix:
-
-- [ ] I ran all tests locally. [Following contributer's guide] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md)
-- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
-
+- [ ] I ran Unit Tests locally.
 
 For significant contributions please make sure you have completed the following items:
 
 - [ ] Changes in public surface reviewed
-- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from a fork - mention one of committers to initiate the build for you.
+- [ ] Design discussion issue #
+- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
+- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
+	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)
+
+- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.

--- a/Readme.md
+++ b/Readme.md
@@ -35,14 +35,15 @@ Developing
 To successfully build the sources on your machine, make sure you've installed the following prerequisites:
 * Visual Studio 2017 Community or Enterprise. Please make sure to install all the latest updates to Visual Studio
 * .NET 4.6
-* .NET Core 2.0
+* .NET Core SDK 1.1.7
+* .NET Core SDK 2.0 or above.(https://www.microsoft.com/net/download/windows)
 
 ## Building
 Once you've installed the prerequisites execute ```buildDebug.cmd``` or ```buildRelease.cmd``` script in the repository root to build the project locally.
 You can also open the solution in Visual Studio and build the ApplicationInsights.AspNetCore.sln solution directly.
 
 ## Testing/Debugging
-Execute the ```runAllTests.cmd``` script in the repository root.
+Execute the ```RunTests.cmd``` script in the repository root.
 
 You can also open the solution in Visual Studio and run tests directly from Visual Studio Test Explorer. However, as the tests has multiple targets, Test Explorer only shows the first target
 from <TargetFrameworks> in .csproj. To debug/run tests from a particular TargetFramework with Visual Studio, only option is to re-arrange the <TargetFrameworks>

--- a/dirs.proj
+++ b/dirs.proj
@@ -3,8 +3,8 @@
     <Import Project="Signing.props"/>
 
     <PropertyGroup>
-        <CliZipFile>$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-sdk-2.0.0-win-x64.zip</CliZipFile>
-        <CliToolsPath>$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-sdk-2.0.0-win-x64.latest</CliToolsPath>
+        <CliZipFile>$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-sdk-2.1.4-win-x64.zip</CliZipFile>
+        <CliToolsPath>$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-sdk-2.1.4-win-x64.latest</CliToolsPath>
         <!-- Library -->
         <ProjectToBuild>.\src\Microsoft.ApplicationInsights.AspNetCore\Microsoft.ApplicationInsights.AspNetCore.csproj</ProjectToBuild>
     </PropertyGroup>
@@ -163,8 +163,8 @@
     </Target>
 
     <Target Name="DownloadCLI">
-        <!--<DownloadFile Address="https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-sdk-2.0.0-win-x64.zip" FileName="$(CliZipFile)" />-->
-		<DownloadFile Address="https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x64.zip" FileName="$(CliZipFile)" />		
+        <!--<DownloadFile Address="https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-sdk-2.1.4-win-x64.zip" FileName="$(CliZipFile)" />-->
+		<DownloadFile Address="https://download.microsoft.com/download/1/1/5/115B762D-2B41-4AF3-9A63-92D9680B9409/dotnet-sdk-2.1.4-win-x64.zip" FileName="$(CliZipFile)" />		
         <ExtractZipArchive InputFiles="$(CliZipFile)" OutputPath="$(CliToolsPath)" ArchiveFileNameAsRootFolder="false" Overwrite="true" />
     </Target>
 
@@ -187,8 +187,8 @@
     <Target Name="Clean">
         <RemoveDir Directories="$(BinRoot)\$(Configuration)" />
         <RemoveDir Directories="$(BaseIntermediateOutputPath)" />
-        <RemoveDir Directories="$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-sdk-2.0.0-win-x64.latest" />
-        <Delete Files="$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-sdk-2.0.0-win-x64.zip" />
+        <RemoveDir Directories="$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-sdk-2.1.4-win-x64.latest" />
+        <Delete Files="$(BUILD_ARTIFACTSTAGINGDIRECTORY)\dotnet-sdk-2.1.4-win-x64.zip" />
     </Target>
 
     <Target Name="AfterBuild" AfterTargets="Test" DependsOnTargets="Test">

--- a/disablestrongnamevalidation.ps1
+++ b/disablestrongnamevalidation.ps1
@@ -1,0 +1,3 @@
+& "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\x64\sn.exe" -Vr *,31bf3856ad364e35
+& "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\sn.exe" -Vr *,31bf3856ad364e35
+# running both the above as a hack which is known to work. Its not clear why both are needed.

--- a/enablestrongnamevalidation.ps1
+++ b/enablestrongnamevalidation.ps1
@@ -1,0 +1,3 @@
+& "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\x64\sn.exe" -Vu *,31bf3856ad364e35
+& "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.2 Tools\sn.exe" -Vu *,31bf3856ad364e35
+# running both the above as a hack which is known to work. Its not clear why both are needed.

--- a/findMsBuild.cmd
+++ b/findMsBuild.cmd
@@ -7,7 +7,7 @@ IF DEFINED MSBUILD (
 )
 
 SET VSWHERE=..\packages\vswhere\tools\vswhere.exe
-IF NOT EXIST "%VSWHERE%" nuget.exe install vswhere -NonInteractive -ExcludeVersion -Source https://www.nuget.org/api/v2 > nul
+IF NOT EXIST "%VSWHERE%" nuget.exe install vswhere -NonInteractive -ExcludeVersion -Source https://www.nuget.org/api/v2 -OutputDirectory ..\packages> nul
 
 FOR /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -version %VSVERSION% -products * -requires Microsoft.Component.MSBuild -property installationPath`) DO (
   SET MSBUILD=%%i\MSBuild\%VSVERSION%\Bin\MSBuild.exe

--- a/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests.csproj
+++ b/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests.csproj
@@ -7,10 +7,7 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>EmptyApp.FunctionalTests</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <AssemblyName>EmptyApp.FunctionalTests</AssemblyName>    
     <PackageId>EmptyApp.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <!--<RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.5</RuntimeFrameworkVersion>-->

--- a/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
+++ b/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
@@ -7,10 +7,7 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>EmptyApp20.FunctionalTests20</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <AssemblyName>EmptyApp20.FunctionalTests20</AssemblyName>    
     <PackageId>EmptyApp20.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>

--- a/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
+++ b/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
@@ -7,7 +7,8 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>EmptyApp20.FunctionalTests20</AssemblyName>    
+    <AssemblyName>EmptyApp20.FunctionalTests20</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>    
     <PackageId>EmptyApp20.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>

--- a/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
+++ b/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
@@ -4,11 +4,9 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
-    <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
+	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>EmptyApp20.FunctionalTests20</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>    
+    <AssemblyName>EmptyApp20.FunctionalTests20</AssemblyName>    
     <PackageId>EmptyApp20.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>

--- a/test/FunctionalTestUtils/FunctionalTestUtils.csproj
+++ b/test/FunctionalTestUtils/FunctionalTestUtils.csproj
@@ -6,9 +6,7 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>FunctionalTestUtils</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
+    <AssemblyName>FunctionalTestUtils</AssemblyName>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>FunctionalTestUtils</PackageId>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>

--- a/test/FunctionalTestUtils/FunctionalTestUtils.csproj
+++ b/test/FunctionalTestUtils/FunctionalTestUtils.csproj
@@ -3,12 +3,9 @@
   <PropertyGroup>
     <VersionPrefix>1.0.2</VersionPrefix>
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6</TargetFrameworks>
-    <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
+	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6</TargetFrameworks>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>FunctionalTestUtils</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>    
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <AssemblyName>FunctionalTestUtils</AssemblyName>        
     <PackageId>FunctionalTestUtils</PackageId>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
 	<OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>

--- a/test/FunctionalTestUtils/FunctionalTestUtils.csproj
+++ b/test/FunctionalTestUtils/FunctionalTestUtils.csproj
@@ -6,7 +6,8 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>FunctionalTestUtils</AssemblyName>    
+    <AssemblyName>FunctionalTestUtils</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>FunctionalTestUtils</PackageId>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>

--- a/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
+++ b/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
@@ -3,12 +3,9 @@
   <PropertyGroup>
     <VersionPrefix>1.0.2</VersionPrefix>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
-    <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
+	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>FunctionalTestUtils20</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>	
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <AssemblyName>FunctionalTestUtils20</AssemblyName>    
     <PackageId>FunctionalTestUtils</PackageId>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
 	<OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>	

--- a/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
+++ b/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
@@ -6,7 +6,8 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>FunctionalTestUtils20</AssemblyName>       
+    <AssemblyName>FunctionalTestUtils20</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>	
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>FunctionalTestUtils</PackageId>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>

--- a/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
+++ b/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
@@ -6,9 +6,7 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>FunctionalTestUtils20</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
+    <AssemblyName>FunctionalTestUtils20</AssemblyName>       
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>FunctionalTestUtils</PackageId>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>

--- a/test/FunctionalTestUtils20/InProcessServer.cs
+++ b/test/FunctionalTestUtils20/InProcessServer.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Net;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.DependencyInjection;
     using Xunit.Abstractions;
@@ -49,7 +50,15 @@
             output.WriteLine(string.Format("{0}: Starting listener at: {1}", DateTime.Now.ToString("G"), this.httpListenerConnectionString));
 
             this.listener = new TelemetryHttpListenerObservable(this.httpListenerConnectionString);
-            this.listener.Start();
+            try
+            {
+                this.listener.Start();
+            }
+            catch(HttpListenerException ex)
+            {
+                output.WriteLine(string.Format("{0}: Error starting listener.ErrorCode {1} Native Code {2}", DateTime.Now.ToString("G"), ex.ErrorCode, ex.NativeErrorCode));
+                throw ex;
+            }
         }
 
         public TelemetryHttpListenerObservable Listener

--- a/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests.csproj
+++ b/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests.csproj
@@ -4,12 +4,9 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
-    <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
+	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>MVCFramework.FunctionalTests</AssemblyName>    
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-	<AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <AssemblyName>MVCFramework.FunctionalTests</AssemblyName>        
     <PackageId>MVCFramework.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <UserSecretsId>aspnet-MVCFramework45.FunctionalTests-60cfc765-2dc9-454c-bb34-dc379ed92cd0</UserSecretsId>

--- a/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests.csproj
+++ b/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests.csproj
@@ -7,9 +7,7 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>MVCFramework.FunctionalTests</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
+    <AssemblyName>MVCFramework.FunctionalTests</AssemblyName>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>MVCFramework.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests.csproj
+++ b/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests.csproj
@@ -9,6 +9,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>MVCFramework.FunctionalTests</AssemblyName>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+	<AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageId>MVCFramework.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <UserSecretsId>aspnet-MVCFramework45.FunctionalTests-60cfc765-2dc9-454c-bb34-dc379ed92cd0</UserSecretsId>

--- a/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
+++ b/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
@@ -7,7 +7,8 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>MVCFramework20.FunctionalTests20</AssemblyName>    
+    <AssemblyName>MVCFramework20.FunctionalTests20</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>MVCFramework.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
+++ b/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
@@ -5,11 +5,8 @@
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
-    <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>MVCFramework20.FunctionalTests20</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>    
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>MVCFramework.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <UserSecretsId>aspnet-MVCFramework45.FunctionalTests-60cfc765-2dc9-454c-bb34-dc379ed92cd0</UserSecretsId>

--- a/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
+++ b/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
@@ -7,9 +7,7 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>MVCFramework20.FunctionalTests20</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
+    <AssemblyName>MVCFramework20.FunctionalTests20</AssemblyName>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>MVCFramework.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -7,7 +7,8 @@
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore.Tests</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>     
+    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.ApplicationInsights.AspNetCore.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -6,7 +6,8 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>Microsoft.ApplicationInsights.AspNetCore.Tests</AssemblyName>    
+    <AssemblyName>Microsoft.ApplicationInsights.AspNetCore.Tests</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>     
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.ApplicationInsights.AspNetCore.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -6,9 +6,7 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>Microsoft.ApplicationInsights.AspNetCore.Tests</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
+    <AssemblyName>Microsoft.ApplicationInsights.AspNetCore.Tests</AssemblyName>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Microsoft.ApplicationInsights.AspNetCore.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/WebApi.FunctionalTests/WebApi.FunctionalTests.csproj
+++ b/test/WebApi.FunctionalTests/WebApi.FunctionalTests.csproj
@@ -5,11 +5,8 @@
     <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
-    <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>WebApi.FunctionalTests</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>    
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <AssemblyName>WebApi.FunctionalTests</AssemblyName>    
     <PackageId>WebApi.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>

--- a/test/WebApi.FunctionalTests/WebApi.FunctionalTests.csproj
+++ b/test/WebApi.FunctionalTests/WebApi.FunctionalTests.csproj
@@ -7,7 +7,8 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>WebApi.FunctionalTests</AssemblyName>    
+    <AssemblyName>WebApi.FunctionalTests</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>WebApi.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/WebApi.FunctionalTests/WebApi.FunctionalTests.csproj
+++ b/test/WebApi.FunctionalTests/WebApi.FunctionalTests.csproj
@@ -7,9 +7,7 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>WebApi.FunctionalTests</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
+    <AssemblyName>WebApi.FunctionalTests</AssemblyName>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>WebApi.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
+++ b/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
@@ -4,12 +4,9 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
-    <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
+	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>WebApi20.FunctionalTests20</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>    
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>WebApi20.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>    
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>

--- a/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
+++ b/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
@@ -7,9 +7,7 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>WebApi20.FunctionalTests20</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
+    <AssemblyName>WebApi20.FunctionalTests20</AssemblyName>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>WebApi20.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>    

--- a/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
+++ b/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
@@ -7,7 +7,8 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>WebApi20.FunctionalTests20</AssemblyName>    
+    <AssemblyName>WebApi20.FunctionalTests20</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../keys/35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>    
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>WebApi20.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>    


### PR DESCRIPTION
added script to disable sn check
Removed signing for test projects - this was causing tests to be not discovered by dotnet test/vstest tools for NET46 targets,

NO product code changes.

Short description of the fix:

- [x] I ran all tests locally. [Following contributer's guide] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md)
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.


For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from a fork - mention one of committers to initiate the build for you.
