### PR TITLE
Enforce limits of values read from incoming headers and app id lookup

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Common/InjectionGuardConstants.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Common/InjectionGuardConstants.cs
@@ -25,6 +25,6 @@
         /// <summary>
         /// Max length of context header value.
         /// </summary>
-        public const int ContextHeaderValueMaxLength = 100;
+        public const int ContextHeaderValueMaxLength = 1024;
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Common/InjectionGuardConstants.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Common/InjectionGuardConstants.cs
@@ -1,0 +1,20 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Common
+{
+    /// <summary>
+    /// These values are listed to guard against malicious injections by limiting the max size allowed in an HTTP Response.
+    /// These max limits are intentionally exaggerated to allow for unexpected responses, while still guarding against unreasonably large responses.
+    /// Example: While a 32 character response may be expected, 50 characters may be permitted while a 10,000 character response would be unreasonable and malicious.
+    /// </summary>
+    public static class InjectionGuardConstants
+    {
+        /// <summary>
+        /// Max length of AppId allowed in response from Breeze.
+        /// </summary>
+        public const int AppIdMaxLengeth = 50;
+
+        /// <summary>
+        /// Max length of incoming Request Header value allowed.
+        /// </summary>
+        public const int RequestHeaderMaxLength = 100;
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Common/InjectionGuardConstants.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Common/InjectionGuardConstants.cs
@@ -16,5 +16,15 @@
         /// Max length of incoming Request Header value allowed.
         /// </summary>
         public const int RequestHeaderMaxLength = 100;
+
+        /// <summary>
+        /// Max length of context header key.
+        /// </summary>
+        public const int ContextHeaderKeyMaxLength = 50;
+
+        /// <summary>
+        /// Max length of context header value.
+        /// </summary>
+        public const int ContextHeaderValueMaxLength = 100;
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Common/InjectionGuardConstants.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Common/InjectionGuardConstants.cs
@@ -15,7 +15,7 @@
         /// <summary>
         /// Max length of incoming Request Header value allowed.
         /// </summary>
-        public const int RequestHeaderMaxLength = 100;
+        public const int RequestHeaderMaxLength = 1024;
 
         /// <summary>
         /// Max length of context header key.

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Common/StringUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Common/StringUtilities.cs
@@ -1,0 +1,26 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Common
+{
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Generic functions to perform common operations on a string.
+    /// </summary>
+    public static class StringUtilities
+    {
+        /// <summary>
+        /// Check a strings length and trim to a max length if needed.
+        /// </summary>
+        public static string EnforceMaxLength(string input, int maxLength)
+        {
+            Debug.Assert(input != null, $"{nameof(input)} must not be null");
+            Debug.Assert(maxLength > 0, $"{nameof(maxLength)} must be greater than 0");
+
+            if (input != null && input.Length > maxLength)
+            {
+                input = input.Substring(0, maxLength);
+            }
+
+            return input;
+        }
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HeadersUtilities.cs
@@ -1,5 +1,6 @@
 namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
 {
+    using Microsoft.ApplicationInsights.AspNetCore.Common;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
@@ -25,7 +26,8 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
                     string[] keyNameValueParts = keyNameValue.Trim().Split('=');
                     if (keyNameValueParts.Length == 2 && keyNameValueParts[0].Trim() == keyName)
                     {
-                        return keyNameValueParts[1].Trim();
+                        string value = keyNameValueParts[1].Trim();
+                        return StringUtilities.EnforceMaxLength(value, InjectionGuardConstants.RequestHeaderMaxLength);
                     }
                 }
             }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HeadersUtilities.cs
@@ -3,6 +3,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Text.RegularExpressions;
 
     /// <summary>
     /// Generic functions that can be used to get and set Http headers.
@@ -93,5 +94,24 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
 
             return true;
         }
+
+        /// <summary>
+        /// Http Headers only allow Printable US-ASCII characters.
+        /// Remove all other characters.
+        /// </summary>
+        public static string SanitizeString(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return input;
+            }
+
+            // US-ASCII characters (hex: 0x00 - 0x7F) (decimal: 0-127)
+            // ASCII Extended characters (hex: 0x80 - 0xFF) (decimal: 0-255) (NOT ALLOWED)
+            // Non-Printable ASCII characters are (hex: 0x00 - 0x1F) (decimal: 0-31) (NOT ALLOWED)
+            // Printable ASCII characters are (hex: 0x20 - 0xFF) (decimal: 32-255) 
+            return Regex.Replace(input, @"[^\u0020-\u007F]", string.Empty);
+        }
+
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -77,7 +77,7 @@
                 {
                     isActivityCreatedFromRequestIdHeader = true;
                 }
-                else if (httpContext.Request.Headers.TryGetValue(RequestResponseHeaders.StandardRootIdHeader, out xmsRequestRootId))
+                else if (httpContext.Request.Headers.TryGetValue(RequestResponseHeaders.StandardRootIdHeader, out xmsRequestRootId)) //todo: guard
                 {
                     var activity = new Activity(ActivityCreatedByHostingDiagnosticListener);
                     activity.SetParentId(xmsRequestRootId);
@@ -113,12 +113,12 @@
                 StringValues requestId;
                 StringValues standardRootId;
                 IHeaderDictionary requestHeaders = httpContext.Request.Headers;
-                if (requestHeaders.TryGetValue(RequestResponseHeaders.RequestIdHeader, out requestId))
+                if (requestHeaders.TryGetValue(RequestResponseHeaders.RequestIdHeader, out requestId)) //todo: guard
                 {
                     isActivityCreatedFromRequestIdHeader = true;
                     activity.SetParentId(requestId);
 
-                    string[] baggage = requestHeaders.GetCommaSeparatedValues(RequestResponseHeaders.CorrelationContextHeader);
+                    string[] baggage = requestHeaders.GetCommaSeparatedValues(RequestResponseHeaders.CorrelationContextHeader); //todo: guard
                     if (baggage != StringValues.Empty)
                     {
                         foreach (var item in baggage)
@@ -131,7 +131,7 @@
                         }
                     }
                 }
-                else if (requestHeaders.TryGetValue(RequestResponseHeaders.StandardRootIdHeader, out standardRootId))
+                else if (requestHeaders.TryGetValue(RequestResponseHeaders.StandardRootIdHeader, out standardRootId)) //todo: guard
                 {
                     activity.SetParentId(standardRootId);
                 }
@@ -207,7 +207,7 @@
                     }
                 }
             }
-            else if (httpContext.Request.Headers.TryGetValue(RequestResponseHeaders.StandardParentIdHeader, out standardParentId))
+            else if (httpContext.Request.Headers.TryGetValue(RequestResponseHeaders.StandardParentIdHeader, out standardParentId)) //todo: guard
             {
                 requestTelemetry.Context.Operation.ParentId = standardParentId;
             }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -121,7 +121,7 @@
                     isActivityCreatedFromRequestIdHeader = true;
                     activity.SetParentId(requestId);
 
-                    string[] baggage = requestHeaders.GetCommaSeparatedValues(RequestResponseHeaders.CorrelationContextHeader); //todo: guard
+                    string[] baggage = requestHeaders.GetCommaSeparatedValues(RequestResponseHeaders.CorrelationContextHeader);
                     if (baggage != StringValues.Empty)
                     {
                         foreach (var item in baggage)
@@ -129,6 +129,8 @@
                             NameValueHeaderValue baggageItem;
                             if (NameValueHeaderValue.TryParse(item, out baggageItem))
                             {
+                                var itemName = StringUtilities.EnforceMaxLength(baggageItem.Name, InjectionGuardConstants.ContextHeaderKeyMaxLength);
+                                var itemValue = StringUtilities.EnforceMaxLength(baggageItem.Value, InjectionGuardConstants.ContextHeaderValueMaxLength);
                                 activity.AddBaggage(baggageItem.Name, baggageItem.Value);
                             }
                         }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -6,6 +6,7 @@
     using System.Net.Http.Headers;
     using System.Reflection;
     using Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.AspNetCore.Common;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -77,8 +78,9 @@
                 {
                     isActivityCreatedFromRequestIdHeader = true;
                 }
-                else if (httpContext.Request.Headers.TryGetValue(RequestResponseHeaders.StandardRootIdHeader, out xmsRequestRootId)) //todo: guard
+                else if (httpContext.Request.Headers.TryGetValue(RequestResponseHeaders.StandardRootIdHeader, out xmsRequestRootId))
                 {
+                    xmsRequestRootId = StringUtilities.EnforceMaxLength(xmsRequestRootId, InjectionGuardConstants.RequestHeaderMaxLength);
                     var activity = new Activity(ActivityCreatedByHostingDiagnosticListener);
                     activity.SetParentId(xmsRequestRootId);
                     activity.Start();
@@ -113,8 +115,9 @@
                 StringValues requestId;
                 StringValues standardRootId;
                 IHeaderDictionary requestHeaders = httpContext.Request.Headers;
-                if (requestHeaders.TryGetValue(RequestResponseHeaders.RequestIdHeader, out requestId)) //todo: guard
+                if (requestHeaders.TryGetValue(RequestResponseHeaders.RequestIdHeader, out requestId))
                 {
+                    requestId = StringUtilities.EnforceMaxLength(requestId, InjectionGuardConstants.RequestHeaderMaxLength);
                     isActivityCreatedFromRequestIdHeader = true;
                     activity.SetParentId(requestId);
 
@@ -131,8 +134,9 @@
                         }
                     }
                 }
-                else if (requestHeaders.TryGetValue(RequestResponseHeaders.StandardRootIdHeader, out standardRootId)) //todo: guard
+                else if (requestHeaders.TryGetValue(RequestResponseHeaders.StandardRootIdHeader, out standardRootId))
                 {
+                    standardRootId = StringUtilities.EnforceMaxLength(standardRootId, InjectionGuardConstants.RequestHeaderMaxLength);
                     activity.SetParentId(standardRootId);
                 }
 
@@ -207,8 +211,9 @@
                     }
                 }
             }
-            else if (httpContext.Request.Headers.TryGetValue(RequestResponseHeaders.StandardParentIdHeader, out standardParentId)) //todo: guard
+            else if (httpContext.Request.Headers.TryGetValue(RequestResponseHeaders.StandardParentIdHeader, out standardParentId))
             {
+                standardParentId = StringUtilities.EnforceMaxLength(standardParentId, InjectionGuardConstants.RequestHeaderMaxLength);
                 requestTelemetry.Context.Operation.ParentId = standardParentId;
             }
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
@@ -47,12 +47,12 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
 
         internal static string GetRequestContextKeyValue(HttpHeaders headers, string keyName)
         {
-            return GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName); //todo: guard
+            return GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName);
         }
 
         internal static string GetRequestContextKeyValue(IHeaderDictionary headers, string keyName)
         {
-            return GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName); //todo: guard
+            return GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName);
         }
 
         internal static bool ContainsRequestContextKeyValue(HttpHeaders headers, string keyName)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
@@ -47,22 +47,22 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
 
         internal static string GetRequestContextKeyValue(HttpHeaders headers, string keyName)
         {
-            return GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName);
+            return GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName); //todo: guard
         }
 
         internal static string GetRequestContextKeyValue(IHeaderDictionary headers, string keyName)
         {
-            return GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName);
+            return GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName); //todo: guard
         }
 
         internal static bool ContainsRequestContextKeyValue(HttpHeaders headers, string keyName)
         {
-            return !string.IsNullOrEmpty(GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName));
+            return !string.IsNullOrEmpty(GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName)); //todo: guard
         }
 
         internal static bool ContainsRequestContextKeyValue(IHeaderDictionary headers, string keyName)
         {
-            return !string.IsNullOrEmpty(GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName));
+            return !string.IsNullOrEmpty(GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName)); //todo: guard
         }
 
         internal static void SetRequestContextKeyValue(HttpHeaders headers, string keyName, string keyValue)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
@@ -57,12 +57,12 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
 
         internal static bool ContainsRequestContextKeyValue(HttpHeaders headers, string keyName)
         {
-            return !string.IsNullOrEmpty(GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName)); //todo: guard
+            return !string.IsNullOrEmpty(GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName));
         }
 
         internal static bool ContainsRequestContextKeyValue(IHeaderDictionary headers, string keyName)
         {
-            return !string.IsNullOrEmpty(GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName)); //todo: guard
+            return !string.IsNullOrEmpty(GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName));
         }
 
         internal static void SetRequestContextKeyValue(HttpHeaders headers, string keyName, string keyValue)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
@@ -128,6 +128,12 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             this.WriteEvent(9, this.ApplicationName);
         }
 
+        [Event(10, Message = "Failed to retrieve App ID for the current application insights resource. Endpoint returned HttpStatusCode: {0}", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
+        public void FetchAppIdFailedWithResponseCode(string exception, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(10, exception, this.ApplicationName);
+        }
+
         /// <summary>
         /// Keywords for the AspNetEventSource.
         /// </summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationCorrelationTelemetryInitializer.cs
@@ -45,7 +45,7 @@
             HttpRequest currentRequest = platformContext.Request;
             if (currentRequest?.Headers != null && string.IsNullOrEmpty(requestTelemetry.Source))
             {
-                string headerCorrelationId = HttpHeadersUtilities.GetRequestContextKeyValue(currentRequest.Headers, RequestResponseHeaders.RequestContextSourceKey);
+                string headerCorrelationId = HttpHeadersUtilities.GetRequestContextKeyValue(currentRequest.Headers, RequestResponseHeaders.RequestContextSourceKey); //todo: guard
                 
                 string appCorrelationId = null;
                 // If the source header is present on the incoming request, and it is an external component (not the same ikey as the one used by the current component), populate the source field.

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationCorrelationTelemetryInitializer.cs
@@ -46,13 +46,13 @@
             HttpRequest currentRequest = platformContext.Request;
             if (currentRequest?.Headers != null && string.IsNullOrEmpty(requestTelemetry.Source))
             {
-                string headerCorrelationId = HttpHeadersUtilities.GetRequestContextKeyValue(currentRequest.Headers, RequestResponseHeaders.RequestContextSourceKey);
-                headerCorrelationId = StringUtilities.EnforceMaxLength(headerCorrelationId, InjectionGuardConstants.AppIdMaxLengeth);
+                string headerCorrelationId = HttpHeadersUtilities.GetRequestContextKeyValue(currentRequest.Headers, RequestResponseHeaders.RequestContextSourceKey);                
 
                 string appCorrelationId = null;
                 // If the source header is present on the incoming request, and it is an external component (not the same ikey as the one used by the current component), populate the source field.
                 if (!string.IsNullOrEmpty(headerCorrelationId))
                 {
+                    headerCorrelationId = StringUtilities.EnforceMaxLength(headerCorrelationId, InjectionGuardConstants.AppIdMaxLengeth);
                     if (string.IsNullOrEmpty(requestTelemetry.Context.InstrumentationKey))
                     {
                         requestTelemetry.Source = headerCorrelationId;

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationCorrelationTelemetryInitializer.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Net.Http.Headers;
+    using Microsoft.ApplicationInsights.AspNetCore.Common;
     using Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
@@ -45,8 +46,9 @@
             HttpRequest currentRequest = platformContext.Request;
             if (currentRequest?.Headers != null && string.IsNullOrEmpty(requestTelemetry.Source))
             {
-                string headerCorrelationId = HttpHeadersUtilities.GetRequestContextKeyValue(currentRequest.Headers, RequestResponseHeaders.RequestContextSourceKey); //todo: guard
-                
+                string headerCorrelationId = HttpHeadersUtilities.GetRequestContextKeyValue(currentRequest.Headers, RequestResponseHeaders.RequestContextSourceKey);
+                headerCorrelationId = StringUtilities.EnforceMaxLength(headerCorrelationId, InjectionGuardConstants.AppIdMaxLengeth);
+
                 string appCorrelationId = null;
                 // If the source header is present on the incoming request, and it is an external component (not the same ikey as the one used by the current component), populate the source field.
                 if (!string.IsNullOrEmpty(headerCorrelationId))

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/CorrelationIdLookupHelperTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/CorrelationIdLookupHelperTest.cs
@@ -15,12 +15,12 @@
         {
             CorrelationIdLookupHelper target = new CorrelationIdLookupHelper((iKey) =>
             {
-                return Task.FromResult(string.Format(CultureInfo.InvariantCulture, "AppId for {0}", iKey));
+                return Task.FromResult(string.Format(CultureInfo.InvariantCulture, "AppId{0}", iKey));
             });
 
             string actual = null;
             target.TryGetXComponentCorrelationId(TestInstrumentationKey, out actual);
-            string expected = string.Format(CultureInfo.InvariantCulture, CorrelationIdLookupHelper.CorrelationIdFormat, "AppId for " + TestInstrumentationKey);
+            string expected = string.Format(CultureInfo.InvariantCulture, CorrelationIdLookupHelper.CorrelationIdFormat, "AppId" + TestInstrumentationKey);
 
             Assert.Equal(expected, actual);
         }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/CorrelationIdLookupHelperTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/CorrelationIdLookupHelperTest.cs
@@ -1,6 +1,8 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests
 {
+    using System;
     using System.Globalization;
+    using System.Threading;
     using System.Threading.Tasks;
     using ApplicationInsights.Extensibility;
     using DiagnosticListeners;
@@ -10,19 +12,68 @@
     {
         private const string TestInstrumentationKey = "11111111-2222-3333-4444-555555555555";
 
+        /// <summary>
+        /// Makes sure that the first call to get app id returns false, because it hasn't been fetched yet.
+        /// But the second call is able to get it from the dictionary.
+        /// </summary>
         [Fact]
-        public void TryGetXComponentCorrelationIdShouldReturnAppIdWhenHit()
+        public void CorrelationIdLookupHelperReturnsAppIdOnSecondCall()
         {
-            CorrelationIdLookupHelper target = new CorrelationIdLookupHelper((iKey) =>
+            var correlationIdLookupHelper = new CorrelationIdLookupHelper((ikey) =>
             {
-                return Task.FromResult(string.Format(CultureInfo.InvariantCulture, "AppId{0}", iKey));
+                // Pretend App Id is the same as Ikey
+                return Task.FromResult(ikey);
             });
 
-            string actual = null;
-            target.TryGetXComponentCorrelationId(TestInstrumentationKey, out actual);
-            string expected = string.Format(CultureInfo.InvariantCulture, CorrelationIdLookupHelper.CorrelationIdFormat, "AppId" + TestInstrumentationKey);
+            string instrumenationKey = Guid.NewGuid().ToString();
+            string cid;
 
-            Assert.Equal(expected, actual);
+            // First call returns false;
+            Assert.False(correlationIdLookupHelper.TryGetXComponentCorrelationId(instrumenationKey, out cid));
+
+            // Let's wait for the task to complete. It should be really quick (based on the test setup) but not immediate.
+            while (correlationIdLookupHelper.IsFetchAppInProgress(instrumenationKey))
+            {
+                Thread.Sleep(10); // wait 10 ms.
+            }
+
+            // Once fetch is complete, subsequent calls should return correlation id.
+            Assert.True(correlationIdLookupHelper.TryGetXComponentCorrelationId(instrumenationKey, out cid));
+        }
+
+        /// <summary>
+        /// Test that if an malicious value is returned, that value will be truncated.
+        /// </summary>
+        [Fact]
+        public void CorrelationIdLookupHelperTruncatesMaliciousValue()
+        {
+            // 50 character string.
+            var value = "a123456789b123546789c123456789d123456798e123456789";
+
+            // An arbitrary string that is expected to be truncated.
+            var malicious = "00000000000000000000000000000000000000000000000000000000000";
+
+            var cidPrefix = "cid-v1:";
+
+            var correlationIdLookupHelper = new CorrelationIdLookupHelper((ikey) =>
+            {
+                return Task.FromResult(value + malicious);
+            });
+
+            string instrumenationKey = Guid.NewGuid().ToString();
+
+            // first request fails because this will create the fetch task.
+            Assert.False(correlationIdLookupHelper.TryGetXComponentCorrelationId(instrumenationKey, out string ignore));
+
+            // Let's wait for the task to complete. It should be really quick (based on the test setup) but not immediate.
+            while (correlationIdLookupHelper.IsFetchAppInProgress(instrumenationKey))
+            {
+                Thread.Sleep(10); // wait 10 ms.
+            }
+
+            // Once fetch is complete, subsequent calls should return correlation id.
+            Assert.True(correlationIdLookupHelper.TryGetXComponentCorrelationId(instrumenationKey, out string cid));
+            Assert.Equal(cidPrefix + value, cid);
         }
 
         [Fact]


### PR DESCRIPTION
Addresses security concerns about malicious user attempting to send request with unreasonably large request headers. As SDK reads these values and stores locally/make part of Telemetry items, they can cause undesirable effects like high mem/cpu/ etc.
This attempts to enforce limits on values read from outside requests/responses.

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
