### PR TITLE
Make all built-in TelemetryInitializers public to enable easy removal

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializer.cs
@@ -8,7 +8,7 @@
     /// <see cref="ITelemetryInitializer"/> implementation that stamps ASP.NET Core environment name
     /// on telemetries.
     /// </summary>
-    internal class AspNetCoreEnvironmentTelemetryInitializer: ITelemetryInitializer
+    public class AspNetCoreEnvironmentTelemetryInitializer: ITelemetryInitializer
     {
         private const string AspNetCoreEnvironmentPropertyName = "AspNetCoreEnvironment";
         private readonly IHostingEnvironment environment;

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AzureWebAppRoleEnvironmentTelemetryInitializer.cs
@@ -10,7 +10,7 @@
     /// <summary>
     /// A telemetry initializer that will gather Azure Web App Role Environment context information.
     /// </summary>
-    internal class AzureWebAppRoleEnvironmentTelemetryInitializer : TelemetryInitializerBase
+    public class AzureWebAppRoleEnvironmentTelemetryInitializer : TelemetryInitializerBase
     {
         /// <summary>Azure Web App name corresponding to the resource name.</summary>
         private const string WebAppNameEnvironmentVariable = "WEBSITE_SITE_NAME";

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/ClientIpHeaderTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/ClientIpHeaderTelemetryInitializer.cs
@@ -13,7 +13,7 @@
     /// <summary>
     /// This telemetry initializer extracts client IP address and populates telemetry.Context.Location.Ip property.
     /// </summary>
-    internal class ClientIpHeaderTelemetryInitializer : TelemetryInitializerBase
+    public class ClientIpHeaderTelemetryInitializer : TelemetryInitializerBase
     {
         private const string HeaderNameDefault = "X-Forwarded-For";
         private readonly char[] headerValuesSeparatorDefault = { ',' };

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
@@ -13,7 +13,7 @@
     /// <summary>
     /// A telemetry initializer that populates cloud context role instance.
     /// </summary>
-    internal class DomainNameRoleInstanceTelemetryInitializer : TelemetryInitializerBase
+    public class DomainNameRoleInstanceTelemetryInitializer : TelemetryInitializerBase
     {
         private string roleInstanceName;
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationCorrelationTelemetryInitializer.cs
@@ -12,7 +12,7 @@
     /// <summary>
     /// A telemetry initializer that will set the correlation context for all telemetry items in web application.
     /// </summary>
-    public class OperationCorrelationTelemetryInitializer : TelemetryInitializerBase
+    internal class OperationCorrelationTelemetryInitializer : TelemetryInitializerBase
     {
         private ICorrelationIdLookupHelper correlationIdLookupHelper = null;
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationCorrelationTelemetryInitializer.cs
@@ -12,7 +12,7 @@
     /// <summary>
     /// A telemetry initializer that will set the correlation context for all telemetry items in web application.
     /// </summary>
-    internal class OperationCorrelationTelemetryInitializer : TelemetryInitializerBase
+    public class OperationCorrelationTelemetryInitializer : TelemetryInitializerBase
     {
         private ICorrelationIdLookupHelper correlationIdLookupHelper = null;
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationNameTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationNameTelemetryInitializer.cs
@@ -6,7 +6,7 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.AspNetCore.Http;
 
-    internal class OperationNameTelemetryInitializer : TelemetryInitializerBase
+    public class OperationNameTelemetryInitializer : TelemetryInitializerBase
     {
         public OperationNameTelemetryInitializer(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
         {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/SyntheticTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/SyntheticTelemetryInitializer.cs
@@ -13,7 +13,7 @@
     /// <summary>
     /// This will allow to mark synthetic traffic from availability tests
     /// </summary>
-    internal class SyntheticTelemetryInitializer : TelemetryInitializerBase
+    public class SyntheticTelemetryInitializer : TelemetryInitializerBase
     {
         private const string SyntheticTestRunId = "SyntheticTest-RunId";
         private const string SyntheticTestLocation = "SyntheticTest-Location";

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/TelemetryInitializerBase.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/TelemetryInitializerBase.cs
@@ -9,7 +9,7 @@
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.DependencyInjection;
 
-    internal abstract class TelemetryInitializerBase : ITelemetryInitializer
+    public abstract class TelemetryInitializerBase : ITelemetryInitializer
     {
         private IHttpContextAccessor httpContextAccessor;
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/WebSessionTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/WebSessionTelemetryInitializer.cs
@@ -5,7 +5,7 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.AspNetCore.Http;
 
-    internal class WebSessionTelemetryInitializer : TelemetryInitializerBase
+    public class WebSessionTelemetryInitializer : TelemetryInitializerBase
     {
         private const string WebSessionCookieName = "ai_session";
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/WebUserTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/WebUserTelemetryInitializer.cs
@@ -5,7 +5,7 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.AspNetCore.Http;
 
-    internal class WebUserTelemetryInitializer : TelemetryInitializerBase
+    public class WebUserTelemetryInitializer : TelemetryInitializerBase
     {
         private const string WebUserCookieName = "ai_user";
 


### PR DESCRIPTION
TelemetryInitializers being internal makes it difficult to remove an individual one. (need reflection magic to achieve this currently)
Fix Issue # .
https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/351
https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/346

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
