### PR TITLE
Fixed multiple instantiations of DependencyTrackingTelemetryModule

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -140,22 +140,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.AddSingleton<ITelemetryInitializer, WebUserTelemetryInitializer>();
                 services.AddSingleton<ITelemetryInitializer, AspNetCoreEnvironmentTelemetryInitializer>();
                 services.AddSingleton<ITelemetryInitializer, HttpDependenciesParsingTelemetryInitializer>();
-                services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>(provider => {
-                    var module = new DependencyTrackingTelemetryModule();
-                    var excludedDomains = module.ExcludeComponentCorrelationHttpHeadersOnDomains;
-                    excludedDomains.Add("core.windows.net");
-                    excludedDomains.Add("core.chinacloudapi.cn");
-                    excludedDomains.Add("core.cloudapi.de");
-                    excludedDomains.Add("core.usgovcloudapi.net");
-                    excludedDomains.Add("localhost");
-                    excludedDomains.Add("127.0.0.1");
-
-                    var includedActivities = module.IncludeDiagnosticSourceActivities;
-                    includedActivities.Add("Microsoft.Azure.EventHubs");
-                    includedActivities.Add("Microsoft.Azure.ServiceBus");
-
-                    return module;
-                });
+                services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>(provider => DefaultDependencyTrackingTelemetryModule.Value);
 
 #if NET451 || NET46
                 services.AddSingleton<ITelemetryModule, PerformanceCollectorModule>();
@@ -333,6 +318,24 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             // We treat ApplicationInsightsInitializer as a marker that AI services were added to service collection
             return services.Any(service => service.ServiceType == typeof(ApplicationInsightsInitializer));
+        }
+
+        private static readonly Lazy<DependencyTrackingTelemetryModule> DefaultDependencyTrackingTelemetryModule = new Lazy<DependencyTrackingTelemetryModule>(() =>
+        {
+            var module = new DependencyTrackingTelemetryModule();
+            var excludedDomains = module.ExcludeComponentCorrelationHttpHeadersOnDomains;
+            excludedDomains.Add("core.windows.net");
+            excludedDomains.Add("core.chinacloudapi.cn");
+            excludedDomains.Add("core.cloudapi.de");
+            excludedDomains.Add("core.usgovcloudapi.net");
+            excludedDomains.Add("localhost");
+            excludedDomains.Add("127.0.0.1");
+
+            var includedActivities = module.IncludeDiagnosticSourceActivities;
+            includedActivities.Add("Microsoft.Azure.EventHubs");
+            includedActivities.Add("Microsoft.Azure.ServiceBus");
+
+            return module;
+        });
     }
-}
 }


### PR DESCRIPTION
Fix Issue https://github.com/Microsoft/ApplicationInsights-dotnet/issues/613.

Prevents multiple instantiations of DependencyTrackingTelemetryModule.

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
