### PR TITLE
update JS snippet with latest from github/applicationinsights-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.3.0-beta1
+- Updated Javascript Snippet with latest from [Github/ApplicationInsights-JS](https://github.com/Microsoft/ApplicationInsights-JS)
+
 ## Version 2.2.1
 - Updated Web/Base SDK version dependency to 2.5.1 which addresses a bug.
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Resources.resx
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Resources.resx
@@ -121,17 +121,16 @@
     <value>appInsights.setAuthenticatedUserContext("{0}");</value>
   </data>
   <data name="JavaScriptSnippet" xml:space="preserve">
-    <value>    &lt;script type="text/javascript"&gt;
-        var appInsights=window.appInsights||function(config){{
-            function i(config){{t[config]=function(){{var i=arguments;t.queue.push(function(){{t[config].apply(t,i)}})}}}}var t={{config:config}},u=document,e=window,o="script",s="AuthenticatedUserContext",h="start",c="stop",l="Track",a=l+"Event",v=l+"Page",y=u.createElement(o),r,f;y.src=config.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js";u.getElementsByTagName(o)[0].parentNode.appendChild(y);try{{t.cookie=u.cookie}}catch(p){{}}for(t.queue=[],t.version="1.0",r=["Event","Exception","Metric","PageView","Trace","Dependency"];r.length;)i("track"+r.pop());return i("set"+s),i("clear"+s),i(h+a),i(c+a),i(h+v),i(c+v),i("flush"),config.disableExceptionTracking||(r="onerror",i("_"+r),f=e[r],e[r]=function(config,i,u,e,o){{var s=f&amp;&amp;f(config,i,u,e,o);return s!==!0&amp;&amp;t["_"+r](config,i,u,e,o),s}}),t
-        }}({{
-            instrumentationKey: '{0}'
-        }});
+    <value>&lt;script type="text/javascript"&gt;
+	
+    var appInsights=window.appInsights||function(a){{
+        function b(a){{c[a]=function(){{var b=arguments;c.queue.push(function(){{c[a].apply(c,b)}})}}}}var c={{config:a}},d=document,e=window;setTimeout(function(){{var b=d.createElement("script");b.src=a.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js",d.getElementsByTagName("script")[0].parentNode.appendChild(b)}});try{{c.cookie=d.cookie}}catch(a){{}}c.queue=[];for(var f=["Event","Exception","Metric","PageView","Trace","Dependency"];f.length;)b("track"+f.pop());if(b("setAuthenticatedUserContext"),b("clearAuthenticatedUserContext"),b("startTrackEvent"),b("stopTrackEvent"),b("startTrackPage"),b("stopTrackPage"),b("flush"),!a.disableExceptionTracking){{f="onerror",b("_"+f);var g=e[f];e[f]=function(a,b,d,e,h){{var i=g&amp;&amp;g(a,b,d,e,h);return!0!==i&amp;&amp;c["_"+f](a,b,d,e,h),i}}}}return c
+    }}({{
+        instrumentationKey: '{0}'
+    }});
 
-        window.appInsights=appInsights;
-        appInsights.trackPageView();
-        {1}
-    &lt;/script&gt;
-</value>
+    window.appInsights=appInsights,appInsights.queue&amp;&amp;0===appInsights.queue.length&amp;&amp;appInsights.trackPageView();
+	{1}
+    &lt;/script&gt;</value>
   </data>
 </root>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/JavaScript/ApplicationInsightsJavaScriptTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/JavaScript/ApplicationInsightsJavaScriptTest.cs
@@ -67,7 +67,7 @@
             string unittestkey = "unittestkey";
             var telemetryConfiguration = new TelemetryConfiguration { InstrumentationKey = unittestkey };
             var snippet = new JavaScriptSnippet(telemetryConfiguration, GetOptions(true), GetHttpContextAccessor("username", false), encoder);
-            Assert.DoesNotContain("setAuthenticatedUserContext", snippet.FullScript);
+            Assert.DoesNotContain("appInsights.setAuthenticatedUserContext(", snippet.FullScript);
         }
 
         [Fact]


### PR DESCRIPTION
Fix Issue # .
Serverside telemetry is not correlated with client side PageViews.
[Reported in WebSDK](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/826)

Fixed by updating with latest snipped from [Github/ApplicationInsights-JS](https://github.com/Microsoft/ApplicationInsights-JS)

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
