### PR TITLE
add fxcop analyzer

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/HttpRequestExtensions.cs
@@ -21,7 +21,7 @@
         {            
             if (null == request)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             if (true == string.IsNullOrWhiteSpace(request.Scheme))

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -50,6 +50,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.2.0-beta2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Composition.Analyzers" Version="1.2.0-beta2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/TelemetryInitializerBase.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/TelemetryInitializerBase.cs
@@ -11,16 +11,11 @@
 
     public abstract class TelemetryInitializerBase : ITelemetryInitializer
     {
-        private IHttpContextAccessor httpContextAccessor;
+        private readonly IHttpContextAccessor httpContextAccessor;
 
         public TelemetryInitializerBase(IHttpContextAccessor httpContextAccessor)
         {
-            if (httpContextAccessor == null)
-            {
-                throw new ArgumentNullException("httpContextAccessor");
-            }
-
-            this.httpContextAccessor = httpContextAccessor;
+            this.httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         }
 
         public void Initialize(ITelemetry telemetry)


### PR DESCRIPTION
Add the FxCop Analyzer to Non-Test projects.
This changed number an analyzer warnings from 304 to 320.
I fixed the 2 nameof() warnings.
New total 218