### PR TITLE
Ensure Heartbeat properties for App Services is included in AspNetCore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.6.0-beta1
+- [Add support for Heartbeat properties in AspNetCore. Add App Services and Azure Instanace Metedata heartbeat provider modules by default, support disable of heartbeats.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/627)
+
 ## Version 2.3.0-beta1
 - Changed behavior for `TelemetryConfiguration.Active` and `TelemetryConfiguration` dependency injection singleton: with this version every WebHost has its own `TelemetryConfiguration` instance. Changes done for `TelemetryConfiguration.Active` do not affect telemetry reported by the SDK; use `TelemetryConfiguration` instance obtained through the dependency injection. [Fix NullReferenceException when sending http requests in scenario with multiple web hosts sharing the same process](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/613)
 - Updated Javascript Snippet with latest from [Github/ApplicationInsights-JS](https://github.com/Microsoft/ApplicationInsights-JS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## Version 2.6.0-beta1
-- [Add support for Heartbeat properties in AspNetCore. Add App Services and Azure Instanace Metedata heartbeat provider modules by default, support disable of heartbeats.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/627)
-
 ## Version 2.3.0-beta1
 - Changed behavior for `TelemetryConfiguration.Active` and `TelemetryConfiguration` dependency injection singleton: with this version every WebHost has its own `TelemetryConfiguration` instance. Changes done for `TelemetryConfiguration.Active` do not affect telemetry reported by the SDK; use `TelemetryConfiguration` instance obtained through the dependency injection. [Fix NullReferenceException when sending http requests in scenario with multiple web hosts sharing the same process](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/613)
 - Updated Javascript Snippet with latest from [Github/ApplicationInsights-JS](https://github.com/Microsoft/ApplicationInsights-JS)
@@ -10,6 +7,7 @@
 - [Enforced limits of values read from incoming http requests to prevent security vulnerability](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/608)
 - [ApplicationInsightsLogger adds EventId into telemetry properties. It is off by default for compatibility. It can be switched on by configuring ApplicationInsightsLoggerOptions.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/569)
 - [ApplicationInsightsLogger logs exceptions as ExceptionTelemetry by default. This can now be configured with ApplicationInsightsLoggerOptions.TrackExceptionsAsExceptionTelemetry] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/574)
+- [Add App Services and Azure Instance Metedata heartbeat provider modules by default, allow user to disable via configuration object.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/627)
 
 ## Version 2.2.1
 - Updated Web/Base SDK version dependency to 2.5.1 which addresses a bug.

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,6 @@
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="applicationinsights" value="https://www.myget.org/F/applicationinsights/api/v3/index.json" />
-    <add key="Local" value="D:\dev\github\ai\bin\Debug\Nuget" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,7 @@
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="applicationinsights" value="https://www.myget.org/F/applicationinsights/api/v3/index.json" />
+    <add key="Local" value="D:\dev\github\ai\bin\Debug\Nuget" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
 #if NET451 || NET46
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
+    using Microsoft.ApplicationInsights.WindowsServer;
 #endif
 
     /// <summary>
@@ -111,6 +112,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 o.EnableQuickPulseMetricStream = options.EnableQuickPulseMetricStream;
                 o.EndpointAddress = options.EndpointAddress;
                 o.InstrumentationKey = options.InstrumentationKey;
+                o.EnableHeartbeat = options.EnableHeartbeat;
             });
             return services;
         }
@@ -128,8 +130,8 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
-                services.AddSingleton<ITelemetryInitializer, AzureWebAppRoleEnvironmentTelemetryInitializer>();
-                services.AddSingleton<ITelemetryInitializer, DomainNameRoleInstanceTelemetryInitializer>();
+                services.AddSingleton<ITelemetryInitializer, ApplicationInsights.AspNetCore.TelemetryInitializers.AzureWebAppRoleEnvironmentTelemetryInitializer>();
+                services.AddSingleton<ITelemetryInitializer, ApplicationInsights.AspNetCore.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer>();
                 services.AddSingleton<ITelemetryInitializer, ComponentVersionTelemetryInitializer>();
                 services.AddSingleton<ITelemetryInitializer, ClientIpHeaderTelemetryInitializer>();
                 services.AddSingleton<ITelemetryInitializer, OperationNameTelemetryInitializer>();
@@ -159,6 +161,8 @@ namespace Microsoft.Extensions.DependencyInjection
 #if NET451 || NET46
                 services.AddSingleton<ITelemetryModule, PerformanceCollectorModule>();
 #endif
+                services.AddSingleton<ITelemetryModule, AppServicesHeartbeatTelemetryModule>();
+                services.AddSingleton<ITelemetryModule, AzureInstanceMetadataTelemetryModule>();
                 services.AddSingleton<TelemetryConfiguration>(provider => provider.GetService<IOptions<TelemetryConfiguration>>().Value);
 
                 services.AddSingleton<ICorrelationIdLookupHelper>(provider => new CorrelationIdLookupHelper(() => provider.GetService<IOptions<TelemetryConfiguration>>().Value));

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.WindowsServer;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
@@ -23,7 +24,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
 #if NET451 || NET46
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
-    using Microsoft.ApplicationInsights.WindowsServer;
 #endif
 
     /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
@@ -17,6 +17,7 @@
             this.EnableAdaptiveSampling = true;
             this.EnableDebugLogger = true;
             this.EnableAuthenticationTrackingJavaScript = false;
+            this.EnableHeartbeat = true;
             this.ApplicationVersion = Assembly.GetEntryAssembly()?.GetName().Version.ToString();
         }
 
@@ -62,5 +63,10 @@
         /// be printed along with the main ApplicationInsights tracking script.
         /// </summary>
         public bool EnableAuthenticationTrackingJavaScript { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether heartbeats are enabled.
+        /// </summary>
+        public bool EnableHeartbeat { get; set; }
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNetCore.Extensions
 {
+    using System;
     using System.Reflection;
 
     /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
-    using Microsoft.ApplicationInsights.WindowsServer;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
     using Microsoft.Extensions.Options;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
     /// Initializes TelemetryConfiguration based on values in <see cref="ApplicationInsightsServiceOptions"/>
@@ -122,11 +122,16 @@ namespace Microsoft.Extensions.DependencyInjection
                     configuration.TelemetryProcessorChainBuilder.UseAdaptiveSampling();
                 }
 
-                if (this.applicationInsightsServiceOptions.EnableHeartbeat)
+                // Disable heartbeat if user sets it (by default it is on)
+                if (!this.applicationInsightsServiceOptions.EnableHeartbeat)
                 {
-                    var heartbeatExtModule = new AppServicesHeartbeatTelemetryModule();
-                    heartbeatExtModule.Initialize(configuration);
-                    TelemetryModules.Instance.Modules.Add(heartbeatExtModule);
+                    foreach (var module in TelemetryModules.Instance.Modules)
+                    {
+                        if (module is IHeartbeatPropertyManager hbeatMan)
+                        {
+                            hbeatMan.IsHeartbeatEnabled = false;
+                        }
+                    }
                 }
             }
         }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -8,8 +8,10 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
+    using Microsoft.ApplicationInsights.WindowsServer;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
     using Microsoft.Extensions.Options;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
     /// <summary>
     /// Initializes TelemetryConfiguration based on values in <see cref="ApplicationInsightsServiceOptions"/>
@@ -118,6 +120,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (this.applicationInsightsServiceOptions.EnableAdaptiveSampling)
                 {
                     configuration.TelemetryProcessorChainBuilder.UseAdaptiveSampling();
+                }
+
+                if (this.applicationInsightsServiceOptions.EnableHeartbeat)
+                {
+                    var heartbeatExtModule = new AppServicesHeartbeatTelemetryModule();
+                    heartbeatExtModule.Initialize(configuration);
+                    TelemetryModules.Instance.Modules.Add(heartbeatExtModule);
                 }
             }
         }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="Microsoft.ApiDesignGuidelines.Analyzers" Version="1.2.0-beta2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.6.0-beta2-build12842" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
@@ -74,15 +73,15 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.0-beta2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.0-beta2-build12842" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.6.0-beta2-build12842" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.6.0-beta2-build12842" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.0-beta2-build14769" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.6.0-beta2-build14769" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.6.0-beta2-build14769" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.6.0-beta2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.6.0-beta2-build12842" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.6.0-beta2-build14769" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.6.0-beta2" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Microsoft.ApiDesignGuidelines.Analyzers" Version="1.2.0-beta2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.6.0-beta2-build12842" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
@@ -72,16 +73,17 @@
     <PackageReference Include="System.Threading.Tasks.Analyzers" Version="1.2.0-beta2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.5.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.5.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.5.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.0-beta2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.6.0-beta2-build12842" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.6.0-beta2-build12842" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.6.0-beta2-build12842" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.6.0-beta2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.5.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.5.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.6.0-beta2-build12842" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.6.0-beta2" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -30,9 +30,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Options;
 
-
-
-
     public static class ApplicationInsightsExtensionsTests
     {
         /// <summary>Constant instrumentation key value for testintg.</summary>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -351,11 +351,11 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.NotNull(modules);
 
 #if NET451 || NET46
-                Assert.Equal(2, modules.Count());
+                Assert.Equal(4, modules.Count());
                 var perfCounterModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(PerformanceCollectorModule));
                 Assert.NotNull(perfCounterModule);
 #else
-                Assert.Equal(1, modules.Count());
+                Assert.Equal(3, modules.Count());
 #endif
 
                 var dependencyModuleDescriptor = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationFactory?.GetMethodInfo().ReturnType == typeof(DependencyTrackingTelemetryModule));

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -505,6 +505,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.Equal(0, qpProcessorCount);
             }
 
+
             [Fact]
             public static void AddsHeartbeatModulesToTheConfigurationByDefault()
             {
@@ -514,15 +515,14 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules.OfType<AppServicesHeartbeatTelemetryModule>().Single());
                 Assert.NotNull(modules.OfType<AzureInstanceMetadataTelemetryModule>().Single());
-
-                var heartbeatModule = TelemetryModules.Instance.Modules.OfType<IHeartbeatPropertyManager>().First();
-                Assert.NotNull(heartbeatModule);
-                Assert.True(heartbeatModule.IsHeartbeatEnabled);
             }
 
             [Fact]
             public static void HeartbeatIsDisabledWithServiceOptions()
             {
+                var heartbeatModulePRE = TelemetryModules.Instance.Modules.OfType<IHeartbeatPropertyManager>().First();
+                Assert.True(heartbeatModulePRE.IsHeartbeatEnabled);
+
                 Action<ApplicationInsightsServiceOptions> serviceOptions = options => options.EnableHeartbeat = false;
                 var services = CreateServicesAndAddApplicationinsightsTelemetry(null, "http://localhost:1234/v2/track/", serviceOptions, false);
                 IServiceProvider serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
Extension of issue Microsoft/ApplicationInsights-dotnet-server#868 "Enabling Heartbeat in App Services..." in .NET Core scenarios.

- [x] I ran Unit Tests locally.
- [x] Changes in public surface reviewed
   - Add EnableHeartbeat to `ApplicationInsightsServiceOptions`, reviewed with @cijothomas 
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
