### PR TITLE
Added extension method to allow configure any TelemetryModule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - [ApplicationInsightsLogger adds EventId into telemetry properties. It is off by default for compatibility. It can be switched on by configuring ApplicationInsightsLoggerOptions.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/569)
 - [ApplicationInsightsLogger logs exceptions as ExceptionTelemetry by default. This can now be configured with ApplicationInsightsLoggerOptions.TrackExceptionsAsExceptionTelemetry] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/574)
 - [Add App Services and Azure Instance Metedata heartbeat provider modules by default, allow user to disable via configuration object.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/627)
+- [Added extension method to allow configuration of any Telemetry Module.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/634)
+- [Added ability to remove any default Telemetry Module.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/633)
 
 ## Version 2.2.1
 - Updated Web/Base SDK version dependency to 2.5.1 which addresses a bug.

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
@@ -134,6 +134,12 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             this.WriteEvent(10, exception, this.ApplicationName);
         }
 
+        [Event(11, Message = "Warning Message: {0}", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
+        public void LogWarningMessage(string message, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(11, message, this.ApplicationName);
+        }
+
         /// <summary>
         /// Keywords for the AspNetEventSource.
         /// </summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
@@ -135,9 +135,9 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         }
 
         [Event(11, Message = "Unable to configure module {0} as it is not found in service collection.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
-        public void UnableToFindModuleToConfigure(Type moduleType, string appDomainName = "Incorrect")
+        public void UnableToFindModuleToConfigure(string moduleType, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(11, moduleType.ToString(), this.ApplicationName);
+            this.WriteEvent(11, moduleType, this.ApplicationName);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
@@ -134,10 +134,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             this.WriteEvent(10, exception, this.ApplicationName);
         }
 
-        [Event(11, Message = "Warning Message: {0}", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
-        public void LogWarningMessage(string message, string appDomainName = "Incorrect")
+        [Event(11, Message = "Unable to configure module {0} as it is not found in service collection.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
+        public void UnableToFindModuleToConfigure(Type moduleType, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(11, message, this.ApplicationName);
+            this.WriteEvent(11, moduleType.ToString(), this.ApplicationName);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -141,8 +141,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.AddSingleton<ITelemetryInitializer, WebUserTelemetryInitializer>();
                 services.AddSingleton<ITelemetryInitializer, AspNetCoreEnvironmentTelemetryInitializer>();
                 services.AddSingleton<ITelemetryInitializer, HttpDependenciesParsingTelemetryInitializer>();
-                services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>(provider => {
-                    var module = new DependencyTrackingTelemetryModule();
+                services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>();
+                services.ConfigureTelemetryModule<DependencyTrackingTelemetryModule>((module) => {                    
                     var excludedDomains = module.ExcludeComponentCorrelationHttpHeadersOnDomains;
                     excludedDomains.Add("core.windows.net");
                     excludedDomains.Add("core.chinacloudapi.cn");
@@ -154,8 +154,6 @@ namespace Microsoft.Extensions.DependencyInjection
                     var includedActivities = module.IncludeDiagnosticSourceActivities;
                     includedActivities.Add("Microsoft.Azure.EventHubs");
                     includedActivities.Add("Microsoft.Azure.ServiceBus");
-
-                    return module;
                 });
 
 #if NET451 || NET46

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -232,7 +232,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </returns>        
         public static IServiceCollection ConfigureTelemetryModule<T>(this IServiceCollection services, Action<T> configModule) where T : ITelemetryModule
         {
-            return services.AddSingleton(typeof(ITelemetryModuleConfigurator), (new TelemetryModuleConfigurator(config => configModule((T)config), typeof(T))));
+            if (configModule == null)
+            {
+                throw new ArgumentNullException(nameof(configModule));
+            }
+
+            return services.AddSingleton(typeof(ITelemetryModuleConfigurator), new TelemetryModuleConfigurator(config => configModule((T)config), typeof(T)));
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -223,6 +223,19 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Extension method to provide configuration logic for application insights telemetry module.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> instance.</param>
+        /// <param name="configModule">Action used to configure the module.</param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/>.
+        /// </returns>        
+        public static IServiceCollection ConfigureTelemetryModule<T>(this IServiceCollection services, Action<T> configModule) where T : ITelemetryModule
+        {
+            return services.AddSingleton(typeof(ITelemetryModuleConfigurator), (new TelemetryModuleConfigurator(config => configModule((T)config), typeof(T))));
+        }
+
+        /// <summary>
         /// Adds Application Insight specific configuration properties to <see cref="IConfigurationBuilder"/>.
         /// </summary>
         /// <param name="configurationSourceRoot">The <see cref="IConfigurationBuilder"/> instance.</param>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/ITelemetryModuleConfigurator.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/ITelemetryModuleConfigurator.cs
@@ -1,0 +1,21 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore
+{    
+    using Microsoft.ApplicationInsights.Extensibility;
+    using System;
+
+    /// <summary>
+    /// Represents method used to configure <see cref="ITelemetryModule"/> with dependency injection support.
+    /// </summary>
+    public interface ITelemetryModuleConfigurator
+    {
+        /// <summary>
+        /// Configures the given <see cref="ITelemetryModule"/>     
+        /// </summary>
+        void Configure(ITelemetryModule telemetryModule);
+
+        /// <summary>
+        /// Gets the type of <see cref="ITelemetryModule"/> to be configured.     
+        /// </summary>
+        Type GetTelemetryModuleType();
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNetCore/ITelemetryModuleConfigurator.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/ITelemetryModuleConfigurator.cs
@@ -16,6 +16,6 @@
         /// <summary>
         /// Gets the type of <see cref="ITelemetryModule"/> to be configured.     
         /// </summary>
-        Type GetTelemetryModuleType();
+        Type TelemetryModuleType { get; }
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                     else
                     {
-                        AspNetCoreEventSource.Instance.UnableToFindModuleToConfigure(telemetryModuleConfigurator.TelemetryModuleType);
+                        AspNetCoreEventSource.Instance.UnableToFindModuleToConfigure(telemetryModuleConfigurator.TelemetryModuleType.ToString());
                     }
                 }
             }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
-    using Microsoft.Extensions.Options;    
+    using Microsoft.Extensions.Options;
 
     /// <summary>
     /// Initializes TelemetryConfiguration based on values in <see cref="ApplicationInsightsServiceOptions"/>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -56,14 +56,14 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 foreach (ITelemetryModuleConfigurator telemetryModuleConfigurator in this.telemetryModuleConfigurators)
                 {                    
-                    ITelemetryModule telemetryModule = this.modules.FirstOrDefault(((module) => module.GetType() == telemetryModuleConfigurator.GetTelemetryModuleType()));
+                    ITelemetryModule telemetryModule = this.modules.FirstOrDefault(((module) => module.GetType() == telemetryModuleConfigurator.TelemetryModuleType));
                     if (telemetryModule != null)
                     {
                         telemetryModuleConfigurator.Configure(telemetryModule);
                     }
                     else
                     {
-                        AspNetCoreEventSource.Instance.LogWarningMessage("Module not found in service collection. Hence will not be configured.");
+                        AspNetCoreEventSource.Instance.UnableToFindModuleToConfigure(telemetryModuleConfigurator.TelemetryModuleType);
                     }
                 }
             }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryModuleConfigurator.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryModuleConfigurator.cs
@@ -8,7 +8,7 @@
     /// </summary>
     internal class TelemetryModuleConfigurator : ITelemetryModuleConfigurator
     {
-        private Action<ITelemetryModule> configure;
+        private readonly Action<ITelemetryModule> configure;
         internal readonly Type telemetryModuleType;
 
         /// <summary>
@@ -19,7 +19,7 @@
         public TelemetryModuleConfigurator(Action<ITelemetryModule> configure, Type telemetryModuleType)
         {
             this.configure = configure;
-            this.telemetryModuleType = telemetryModuleType;
+            this.TelemetryModuleType = telemetryModuleType;
         }
 
         /// <summary>
@@ -35,9 +35,6 @@
         /// <summary>
         /// Gets the type of <see cref="ITelemetryModule"/> to be configured.     
         /// </summary>
-        public Type GetTelemetryModuleType()
-        {
-            return this.telemetryModuleType;
-        }
+        public Type TelemetryModuleType { get; }
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryModuleConfigurator.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryModuleConfigurator.cs
@@ -1,0 +1,43 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore
+{
+    using System;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    /// <summary>
+    /// Represents method used to configure <see cref="ITelemetryModule"/> with dependency injection support.
+    /// </summary>
+    internal class TelemetryModuleConfigurator : ITelemetryModuleConfigurator
+    {
+        private Action<ITelemetryModule> configure;
+        internal readonly Type telemetryModuleType;
+
+        /// <summary>
+        /// Constructs an instance of <see cref="TelemetryModuleConfigurator"/>.
+        /// </summary>        
+        /// <param name="configure">The action used to configure telemetry module.</param>
+        /// <param name="telemetryModuleType">The type of the telemetry module being configured.</param>
+        public TelemetryModuleConfigurator(Action<ITelemetryModule> configure, Type telemetryModuleType)
+        {
+            this.configure = configure;
+            this.telemetryModuleType = telemetryModuleType;
+        }
+
+        /// <summary>
+        /// Creates an instance of the telemetry processor, passing the
+        /// next <see cref="ITelemetryProcessor"/> in the call chain to
+        /// its constructor.
+        /// </summary>
+        public void Configure(ITelemetryModule telemetryModule)
+        {
+            this.configure?.Invoke(telemetryModule);
+        }
+
+        /// <summary>
+        /// Gets the type of <see cref="ITelemetryModule"/> to be configured.     
+        /// </summary>
+        public Type GetTelemetryModuleType()
+        {
+            return this.telemetryModuleType;
+        }
+    }
+}

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -344,12 +344,12 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
 
-#if NET451 || NET46
+#if NET46
                 Assert.Equal(2, modules.Count());
                 var perfCounterModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(PerformanceCollectorModule));
                 Assert.NotNull(perfCounterModule);
 #else
-                Assert.Equal(1, modules.Count());
+                Assert.Single(modules);
 #endif
 
                 var dependencyModuleDescriptor = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationFactory?.GetMethodInfo().ReturnType == typeof(DependencyTrackingTelemetryModule));

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -403,6 +403,60 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             }
 
             [Fact]
+            public static void ConfigureApplicationInsightsTelemetryModuleWorks()
+            {
+                //ARRANGE
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                services.AddSingleton<ITelemetryModule, TestTelemetryModule>();
+
+                //ACT
+                services.ConfigureTelemetryModule<TestTelemetryModule>
+                (module => module.CustomProperty = "mycustomvalue");
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
+                IServiceProvider serviceProvider = services.BuildServiceProvider();
+                
+                // Requesting TelemetryConfiguration from services trigger constructing the TelemetryConfiguration
+                // which in turn trigger configuration of all modules.
+                var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
+
+                //VALIDATE
+                var modules = serviceProvider.GetServices<ITelemetryModule>();                
+                var testTelemetryModule = modules.OfType<TestTelemetryModule>().Single();
+
+                //The module should be initialized and configured as instructed.
+                Assert.NotNull(testTelemetryModule);
+                Assert.Equal("mycustomvalue", testTelemetryModule.CustomProperty);
+                Assert.True(testTelemetryModule.IsInitialized);
+            }
+
+            [Fact]
+            public static void ConfigureApplicationInsightsTelemetryModuleDoesNotThrowIfModuleNotFound()
+            {
+                //ARRANGE
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                // Intentionally NOT adding the module
+                // services.AddSingleton<ITelemetryModule, TestTelemetryModule>();
+
+                //ACT
+                services.ConfigureTelemetryModule<TestTelemetryModule>
+                (module => module.CustomProperty = "mycustomvalue");
+                services.AddApplicationInsightsTelemetry(new ConfigurationBuilder().Build());
+                IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+                // Requesting TelemetryConfiguration from services trigger constructing the TelemetryConfiguration
+                // which in turn trigger configuration of all modules.
+                var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
+
+                //VALIDATE
+                var modules = serviceProvider.GetServices<ITelemetryModule>();
+                var testTelemetryModule = modules.OfType<TestTelemetryModule>().FirstOrDefault();
+
+                // No exceptions thrown here.
+                Assert.Null(testTelemetryModule);                
+            }
+
+
+            [Fact]
             public static void AddsAddaptiveSamplingServiceToTheConfigurationByDefault()
             {                                
                 var services = CreateServicesAndAddApplicationinsightsTelemetry(null, "http://localhost:1234/v2/track/", null, false);

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -430,6 +430,24 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             }
 
             [Fact]
+            public static void ConfigureApplicationInsightsTelemetryModuleThrowsIfConfigureIsNull()
+            {
+                //ARRANGE
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                services.AddSingleton<ITelemetryModule, TestTelemetryModule>();
+
+                //ACT
+                try
+                {
+                    services.ConfigureTelemetryModule<TestTelemetryModule>(null);
+                }
+                catch(ArgumentNullException exThrown)
+                {
+                    Assert.Contains("configModule", exThrown.Message);
+                }
+            }
+
+            [Fact]
             public static void ConfigureApplicationInsightsTelemetryModuleDoesNotThrowIfModuleNotFound()
             {
                 //ARRANGE

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessor.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessor.cs
@@ -19,7 +19,7 @@
             this.IsInitialized = false;
         }
 
-        public bool IsInitialized { get; private set; }        
+        public bool IsInitialized { get; private set; }
 
         public void Initialize(TelemetryConfiguration configuration)
         {

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessor.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/FakeTelemetryProcessor.cs
@@ -19,7 +19,7 @@
             this.IsInitialized = false;
         }
 
-        public bool IsInitialized { get; private set; }
+        public bool IsInitialized { get; private set; }        
 
         public void Initialize(TelemetryConfiguration configuration)
         {

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TestTelemetryModule.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TestTelemetryModule.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests
+{
+    using System;    
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    internal class TestTelemetryModule : ITelemetryModule
+    {        
+        public TestTelemetryModule()
+        {                        
+            this.IsInitialized = false;
+        }
+
+        public bool IsInitialized { get; private set; }
+
+        public string CustomProperty { get; set; }
+
+        public void Initialize(TelemetryConfiguration configuration)
+        {
+            this.IsInitialized = true;
+        }
+    }
+}


### PR DESCRIPTION
More tests are needed. Submitting a PR to get early feedback before I spend too much time.

Pending: 
Document how to use this in Wiki.
Determine what to do if the Module is not found. Throw? Or just log and move on? 
Make SDK also use this extension to configure DependencyCollector.

Fix Issue # .
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
