### PR TITLE
Make QuickPulse configurable by adding it to DI like all other modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [Added ability to remove any default Telemetry Module.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/633)
 - [TelemetryChannel is configured via DI, making it easier to override channel](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/641)
 - [Fixed a bug which caused QuickPulse and Sampling to be enabled only if ServerTelemetryChannel was used](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/642)
+- [QuickPulseTelemetryModule is constructed via DI, make it possible for users to configure it.] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/639)
 
 ## Version 2.2.1
 - Updated Web/Base SDK version dependency to 2.5.1 which addresses a bug.

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
@@ -140,7 +140,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             this.WriteEvent(11, moduleType, this.ApplicationName);
         }
 
-        [Event(12, Message = "Unable to find QuickPulseTelemetryModule in service collection. QuickPulse/LiveMetrics feature will not be available.", Level = EventLevel.Error, Keywords = Keywords.Diagnostics)]
+        [Event(12, Message = "Unable to find QuickPulseTelemetryModule in service collection. LiveMetrics feature will not be available. Please add QuickPulseTelemetryModule to services collection in the ConfigureServices method of your application Startup class.", Level = EventLevel.Error, Keywords = Keywords.Diagnostics)]
         public void UnableToFindQuickPulseModuleInDI(string appDomainName = "Incorrect")
         {
             this.WriteEvent(12, this.ApplicationName);

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
@@ -140,10 +140,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             this.WriteEvent(11, moduleType, this.ApplicationName);
         }
 
-        [Event(12, Message = "Unable to find expected module {0} in service collection.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
-        public void UnableToFindExpectedModule(string moduleType, string appDomainName = "Incorrect")
+        [Event(12, Message = "Unable to find QuickPulseTelemetryModule in service collection. QuickPulse/LiveMetrics feature will not be available.", Level = EventLevel.Error, Keywords = Keywords.Diagnostics)]
+        public void UnableToFindQuickPulseModuleInDI(string appDomainName = "Incorrect")
         {
-            this.WriteEvent(12, moduleType, this.ApplicationName);
+            this.WriteEvent(12, this.ApplicationName);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
@@ -140,6 +140,12 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             this.WriteEvent(11, moduleType, this.ApplicationName);
         }
 
+        [Event(12, Message = "Unable to find expected module {0} in service collection.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
+        public void UnableToFindExpectedModule(string moduleType, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(12, moduleType, this.ApplicationName);
+        }
+
         /// <summary>
         /// Keywords for the AspNetEventSource.
         /// </summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.Extensions.Options;
 
 #if NET451 || NET46
-    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;    
+    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
 #endif
 
     /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
     using Microsoft.ApplicationInsights.WindowsServer;    
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
     using Microsoft.AspNetCore.Hosting;
@@ -25,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.Extensions.Options;
 
 #if NET451 || NET46
-    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
+    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;    
 #endif
 
     /// <summary>
@@ -164,6 +165,7 @@ namespace Microsoft.Extensions.DependencyInjection
 #endif
                 services.AddSingleton<ITelemetryModule, AppServicesHeartbeatTelemetryModule>();
                 services.AddSingleton<ITelemetryModule, AzureInstanceMetadataTelemetryModule>();
+                services.AddSingleton<ITelemetryModule, QuickPulseTelemetryModule>();
                 services.AddSingleton<TelemetryConfiguration>(provider => provider.GetService<IOptions<TelemetryConfiguration>>().Value);
 
                 services.AddSingleton<ICorrelationIdLookupHelper>(provider => new CorrelationIdLookupHelper(() => provider.GetService<IOptions<TelemetryConfiguration>>().Value));

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -78,16 +78,15 @@ namespace Microsoft.Extensions.DependencyInjection
                 }                
             }
 
+            // Fallback to default channel (InMemoryChannel) created by base sdk if no channel is found in DI
+            configuration.TelemetryChannel = this.telemetryChannel ?? configuration.TelemetryChannel;
+            (configuration.TelemetryChannel as ITelemetryModule)?.Initialize(configuration);
+
             this.AddQuickPulse(configuration);
             this.AddSampling(configuration);
             this.DisableHeartBeatIfConfigured();
-
-            (configuration.TelemetryChannel as ITelemetryModule)?.Initialize(configuration);
-
-            configuration.TelemetryProcessorChainBuilder.Build();
-
-            // Fallback to default channel (InMemoryChannel) created by base sdk if no channel is found in DI
-            configuration.TelemetryChannel = this.telemetryChannel ?? configuration.TelemetryChannel;
+            
+            configuration.TelemetryProcessorChainBuilder.Build();            
 
             if (this.applicationInsightsServiceOptions.DeveloperMode != null)
             {
@@ -122,10 +121,7 @@ namespace Microsoft.Extensions.DependencyInjection
         private void AddQuickPulse(TelemetryConfiguration configuration)
         {
             if (this.applicationInsightsServiceOptions.EnableQuickPulseMetricStream)
-            {
-                //var quickPulseModule = new QuickPulseTelemetryModule();
-                //quickPulseModule.Initialize(configuration);                
-
+            {              
                 QuickPulseTelemetryModule quickPulseModule = this.modules.FirstOrDefault(((module) => module.GetType() == typeof(QuickPulseTelemetryModule))) as QuickPulseTelemetryModule;
                 if (quickPulseModule != null)
                 {                    

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
                 else
                 {
-                    AspNetCoreEventSource.Instance.UnableToFindExpectedModule(nameof(QuickPulseTelemetryModule));
+                    AspNetCoreEventSource.Instance.UnableToFindQuickPulseModuleInDI();
                 }                
             }        
         }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.DependencyInjection
             this.modules = modules;
             this.telemetryProcessorFactories = telemetryProcessorFactories;
             this.telemetryModuleConfigurators = telemetryModuleConfigurators;
-            this.telemetryChannel = serviceProvider.GetService<ITelemetryChannel>();            
+            this.telemetryChannel = serviceProvider.GetService<ITelemetryChannel>();
         }
 
         /// <inheritdoc />

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -348,15 +348,24 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.NotNull(modules);
 
 #if NET46
-                Assert.Equal(4, modules.Count());
+                Assert.Equal(5, modules.Count());
                 var perfCounterModule = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(PerformanceCollectorModule));
                 Assert.NotNull(perfCounterModule);
 #else
-                Assert.Equal(3, modules.Count());
+                Assert.Equal(4, modules.Count());
 #endif
 
                 var dependencyModuleDescriptor = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(DependencyTrackingTelemetryModule));
-                Assert.NotNull(dependencyModuleDescriptor);                
+                Assert.NotNull(dependencyModuleDescriptor);
+               
+                var appServiceHeartBeatModuleDescriptor = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(AppServicesHeartbeatTelemetryModule));
+                Assert.NotNull(appServiceHeartBeatModuleDescriptor);
+
+                var azureMetadataHeartBeatModuleDescriptor = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(AzureInstanceMetadataTelemetryModule));
+                Assert.NotNull(azureMetadataHeartBeatModuleDescriptor);
+
+                var quickPulseModuleDescriptor = services.FirstOrDefault<ServiceDescriptor>(t => t.ImplementationType == typeof(QuickPulseTelemetryModule));
+                Assert.NotNull(quickPulseModuleDescriptor);
             }
             [Fact]
             public static void RegistersTelemetryConfigurationFactoryMethodThatPopulatesDependencyCollectorWithDefaultValues()


### PR DESCRIPTION
Add QuickPulseTelememodule to DI so as to enable retrieval and configuration of the same by user. 

QP is enabled by configuring it based on the user supplied flag EnableQuickPulse as before. But now users can use the extension method services.ConfigureTelemetryModule<QPModule>() to configure QP module.

Fix Issue #639 

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
