### PR TITLE
AddApplicationInsightsTelemetry also reads ikey from appsettings.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Version 2.3.0-beta2
+- [Fix reading of instrumentation key from appsettings.json file when using AddApplicationInsightsTelemetry() extension to add ApplicationInsights ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/605)
+## Version 2.3.0-beta2
 - [Update System.Net.Http version referred to 4.3.2 as older version has known security vulnerability. ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/666)
 - [Added ApplicationInsightsServiceOptions flag to turn off AutoCollectedMetricExtractor. ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/664)
 - [Added two AdaptiveSamplingTelemetryProcessors one for Event and one for non Event types to be consistent with default Web SDK behaviour. ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/663)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 2.3.0-beta2
+## Version 2.3.0
 - [Fix reading of instrumentation key from appsettings.json file when using AddApplicationInsightsTelemetry() extension to add ApplicationInsights ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/605)
 ## Version 2.3.0-beta2
 - [Update System.Net.Http version referred to 4.3.2 as older version has known security vulnerability. ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/666)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -176,6 +176,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 services.AddSingleton<ApplicationInsightsDebugLogger, ApplicationInsightsDebugLogger>();
 
+                services.TryAddSingleton<IConfigureOptions<ApplicationInsightsServiceOptions>, DefaultApplicationInsightsServiceConfigureOptions>();
+
                 // Using startup filter instead of starting DiagnosticListeners directly because
                 // AspNetCoreHostingDiagnosticListener injects TelemetryClient that injects TelemetryConfiguration
                 // that requires IOptions infrastructure to run and initialize

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsWebHostBuilderExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsWebHostBuilderExtensions.cs
@@ -19,8 +19,7 @@
         {
             webHostBuilder.ConfigureServices(collection =>
             {
-                collection.AddApplicationInsightsTelemetry();
-                collection.TryAddSingleton<IConfigureOptions<ApplicationInsightsServiceOptions>, DefaultApplicationInsightsServiceConfigureOptions>();
+                collection.AddApplicationInsightsTelemetry();                
             });
 
             return webHostBuilder;

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             var services = new ServiceCollection();
             IHttpContextAccessor contextAccessor = new HttpContextAccessor();
             services.AddSingleton<IHttpContextAccessor>(contextAccessor);
-            services.AddSingleton<IHostingEnvironment>(new HostingEnvironment());
+            services.AddSingleton<IHostingEnvironment>(new HostingEnvironment() { ContentRootPath = Directory.GetCurrentDirectory()});
             services.AddSingleton<DiagnosticListener>(new DiagnosticListener("TestListener"));
             return services;
         }
@@ -187,6 +187,103 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 finally
                 {
                     Environment.SetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY", null);
+                }
+            }
+
+            [Fact]
+            public static void AddApplicationInsightsTelemetryReadsInstrumentationKeyFromEnvironment()
+            {
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();                
+                Environment.SetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY", TestInstrumentationKey);                
+                try
+                {
+                    services.AddApplicationInsightsTelemetry();
+                    IServiceProvider serviceProvider = services.BuildServiceProvider();
+                    var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
+                    Assert.Equal(TestInstrumentationKey, telemetryConfiguration.InstrumentationKey);
+                }
+                finally
+                {
+                    Environment.SetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY", null);
+                }
+            }
+
+            /// <summary>
+            /// Validates that services.AddApplicationInsightsTelemetry(); reads ikey/other settings from
+            /// appsettings.json
+            /// </summary>
+            [Fact]
+            public static void AddApplicationInsightsTelemetryReadsInstrumentationKeyFromDefaultAppsettingsFile()
+            {
+                string ikeyExpected = Guid.NewGuid().ToString();
+                string hostExpected = "http://ainewhost/v2/track/";
+                string text = File.ReadAllText("appsettings.json");
+                string originalText = text;
+                try
+                {
+                    text = text.Replace("ikeyhere", ikeyExpected);
+                    text = text.Replace("http://hosthere/v2/track/", hostExpected);
+                    File.WriteAllText("appsettings.json", text);
+
+                    var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                    services.AddApplicationInsightsTelemetry();
+                    IServiceProvider serviceProvider = services.BuildServiceProvider();
+                    var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
+                    Assert.Equal(ikeyExpected, telemetryConfiguration.InstrumentationKey);
+                    Assert.Equal(hostExpected, telemetryConfiguration.TelemetryChannel.EndpointAddress);
+                }
+                finally
+                {                    
+                    File.WriteAllText("appsettings.json", originalText);
+                }
+            }
+
+            [Fact]
+            public static void AddApplicationInsightsTelemetryDoesNotReadInstrumentationKeyFromDefaultAppsettingsIfSupplied()
+            {
+                string suppliedIKey = "suppliedikey";
+                string ikey = Guid.NewGuid().ToString();
+                string text = File.ReadAllText("appsettings.json");
+                try
+                {
+                    text = text.Replace("ikeyhere", ikey);
+                    File.WriteAllText("appsettings.json", text);
+
+                    var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                    services.AddApplicationInsightsTelemetry(suppliedIKey);
+                    IServiceProvider serviceProvider = services.BuildServiceProvider();
+                    var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
+                    Assert.Equal(suppliedIKey, telemetryConfiguration.InstrumentationKey);
+                }
+                finally
+                {
+                    text = text.Replace(ikey, "ikeyhere");
+                    File.WriteAllText("appsettings.json", text);
+                }
+            }
+
+            [Fact]
+            public static void AddApplicationInsightsTelemetryDoesNotReadInstrumentationKeyFromDefaultAppsettingsIfSuppliedViaOptions()
+            {
+                string suppliedIKey = "suppliedikey";
+                var options = new ApplicationInsightsServiceOptions() { InstrumentationKey = suppliedIKey };
+                string ikey = Guid.NewGuid().ToString();
+                string text = File.ReadAllText("appsettings.json");
+                try
+                {
+                    text = text.Replace("ikeyhere", ikey);
+                    File.WriteAllText("appsettings.json", text);
+
+                    var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                    services.AddApplicationInsightsTelemetry(options);
+                    IServiceProvider serviceProvider = services.BuildServiceProvider();
+                    var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
+                    Assert.Equal(suppliedIKey, telemetryConfiguration.InstrumentationKey);
+                }
+                finally
+                {
+                    text = text.Replace(ikey, "ikeyhere");
+                    File.WriteAllText("appsettings.json", text);
                 }
             }
 

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -59,6 +59,9 @@
     <None Update="content\config-endpoint-address.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="content\config-instrumentation-key-new.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/appsettings.json
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/appsettings.json
@@ -1,0 +1,8 @@
+﻿{
+  "ApplicationInsights": {
+    "InstrumentationKey": "ikeyhere",
+    "TelemetryChannel": {
+      "EndpointAddress": "http://hosthere/v2/track/"
+    }
+  }
+}


### PR DESCRIPTION
Fix Issue #605 .
DefaultApplicationInsightsServiceConfigureOptions was not injected when using extension method AddApplicationInsightsTelemetry , which meant that ikey was not read from env/appsettings when using this extension method. This PR makes the behaviour consistent with UseApplicationInsights() extension method, which had injected DefaultApplicationInsightsServiceConfigureOptions , and hence read ikey/other settings from appsettigs.json

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
