### PR TITLE
 Bring back DomainNameRoleInstanceTelemetryInitializer to fix bug 671

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version 2.3.0
 - [Fix reading of instrumentation key from appsettings.json file when using AddApplicationInsightsTelemetry() extension to add ApplicationInsights ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/605)
+- [Bring back DomainNameRoleInstanceTelemetryInitializer without which NodeName and RoleInstance will be empty in Ubuntu](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/671)
+
 ## Version 2.3.0-beta2
 - [Update System.Net.Http version referred to 4.3.2 as older version has known security vulnerability. ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/666)
 - [Added ApplicationInsightsServiceOptions flag to turn off AutoCollectedMetricExtractor. ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/664)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -134,6 +134,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
+                services.AddSingleton<ITelemetryInitializer, ApplicationInsights.AspNetCore.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer>();
                 services.AddSingleton<ITelemetryInitializer, AzureWebAppRoleEnvironmentTelemetryInitializer>();                
                 services.AddSingleton<ITelemetryInitializer, ComponentVersionTelemetryInitializer>();
                 services.AddSingleton<ITelemetryInitializer, ClientIpHeaderTelemetryInitializer>();

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
@@ -5,33 +5,22 @@
     using System.Net;
     using System.Net.NetworkInformation;
     using System.Threading;
-    using Channel;
-    using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.AspNetCore.Http;
+    using Channel;    
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;    
 
     /// <summary>
     /// A telemetry initializer that populates cloud context role instance.
     /// </summary>
-    public class DomainNameRoleInstanceTelemetryInitializer : TelemetryInitializerBase
+    public class DomainNameRoleInstanceTelemetryInitializer : ITelemetryInitializer
     {
         private string roleInstanceName;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DomainNameRoleInstanceTelemetryInitializer" /> class.
-        /// </summary>
-        /// <param name="httpContextAccessor">HTTP context accessor.</param>
-        public DomainNameRoleInstanceTelemetryInitializer(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
-        {
-        }
-
-        /// <summary>
         /// Initializes role instance name and node name with the host name.
-        /// </summary>
-        /// <param name="platformContext">Platform context.</param>
-        /// <param name="requestTelemetry">Request telemetry.</param>
+        /// </summary>        
         /// <param name="telemetry">Telemetry item.</param>
-        protected override void OnInitializeTelemetry(HttpContext platformContext, RequestTelemetry requestTelemetry, ITelemetry telemetry)
+        public void Initialize(ITelemetry telemetry)
         {
             if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleInstance))
             {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
@@ -1,0 +1,65 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers
+{
+    using System;
+    using System.Globalization;
+    using System.Net;
+    using System.Net.NetworkInformation;
+    using System.Threading;
+    using Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.AspNetCore.Http;
+
+    /// <summary>
+    /// A telemetry initializer that populates cloud context role instance.
+    /// </summary>
+    public class DomainNameRoleInstanceTelemetryInitializer : TelemetryInitializerBase
+    {
+        private string roleInstanceName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DomainNameRoleInstanceTelemetryInitializer" /> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">HTTP context accessor.</param>
+        public DomainNameRoleInstanceTelemetryInitializer(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+        {
+        }
+
+        /// <summary>
+        /// Initializes role instance name and node name with the host name.
+        /// </summary>
+        /// <param name="platformContext">Platform context.</param>
+        /// <param name="requestTelemetry">Request telemetry.</param>
+        /// <param name="telemetry">Telemetry item.</param>
+        protected override void OnInitializeTelemetry(HttpContext platformContext, RequestTelemetry requestTelemetry, ITelemetry telemetry)
+        {
+            if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleInstance))
+            {
+                var name = LazyInitializer.EnsureInitialized(ref this.roleInstanceName, this.GetMachineName);
+                telemetry.Context.Cloud.RoleInstance = name;
+            }
+
+            InternalContext internalContext = telemetry.Context.GetInternalContext();
+            if (string.IsNullOrEmpty(internalContext.NodeName))
+            {
+                var name = LazyInitializer.EnsureInitialized(ref this.roleInstanceName, this.GetMachineName);
+                internalContext.NodeName = name;
+            }
+        }
+
+        private string GetMachineName()
+        {
+            string hostName = Dns.GetHostName();
+
+            // Issue #61: For dnxcore machine name does not have domain name like in full framework 
+#if !NETSTANDARD1_6
+            string domainName = IPGlobalProperties.GetIPGlobalProperties().DomainName;
+            if (!hostName.EndsWith(domainName, StringComparison.OrdinalIgnoreCase))
+            {
+                hostName = string.Format(CultureInfo.InvariantCulture, "{0}.{1}", hostName, domainName);
+            }
+#endif
+            return hostName;
+        }
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
@@ -27,13 +27,6 @@
                 var name = LazyInitializer.EnsureInitialized(ref this.roleInstanceName, this.GetMachineName);
                 telemetry.Context.Cloud.RoleInstance = name;
             }
-
-            InternalContext internalContext = telemetry.Context.GetInternalContext();
-            if (string.IsNullOrEmpty(internalContext.NodeName))
-            {
-                var name = LazyInitializer.EnsureInitialized(ref this.roleInstanceName, this.GetMachineName);
-                internalContext.NodeName = name;
-            }
         }
 
         private string GetMachineName()

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         public static class AddApplicationInsightsTelemetry
         {
             [Theory]
+            [InlineData(typeof(ITelemetryInitializer), typeof(ApplicationInsights.AspNetCore.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(AzureWebAppRoleEnvironmentTelemetryInitializer), ServiceLifetime.Singleton)]            
             [InlineData(typeof(ITelemetryInitializer), typeof(ComponentVersionTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(ClientIpHeaderTelemetryInitializer), ServiceLifetime.Singleton)]
@@ -69,6 +70,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             }
 
             [Theory]
+            [InlineData(typeof(ITelemetryInitializer), typeof(ApplicationInsights.AspNetCore.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(AzureWebAppRoleEnvironmentTelemetryInitializer), ServiceLifetime.Singleton)]            
             [InlineData(typeof(ITelemetryInitializer), typeof(ComponentVersionTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(ClientIpHeaderTelemetryInitializer), ServiceLifetime.Singleton)]

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -929,7 +929,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             /// Sanity check to validate that node name and roleinstance are populated
             /// </summary>
             [Fact]
-            public static void SanityCheckNodeNameRoleInstance()
+            public static void SanityCheckRoleInstance()
             {
                 // ARRANGE
                 string expected = Environment.MachineName;
@@ -947,9 +947,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 tc.Initialize(mockItem);
 
                 // VERIFY                
-                Assert.Contains(expected,mockItem.Context.Cloud.RoleInstance, StringComparison.CurrentCultureIgnoreCase);
-                Assert.Contains(expected,mockItem.Context.GetInternalContext().NodeName, StringComparison.CurrentCultureIgnoreCase);
-                
+                Assert.Contains(expected,mockItem.Context.Cloud.RoleInstance, StringComparison.CurrentCultureIgnoreCase);                                
             }
         }
 

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializerTests.cs
@@ -13,42 +13,12 @@
 
     public class DomainNameRoleInstanceTelemetryInitializerTests
     {
-        private const string TestListenerName = "TestListener";
-
-        [Fact]
-        public void InitializeThrowIfHttpContextAccessorIsNull()
-        {
-            Assert.ThrowsAny<ArgumentNullException>(() =>
-            {
-                var initializer = new DomainNameRoleInstanceTelemetryInitializer(null);
-            });
-        }
-
-        [Fact]
-        public void InitializeDoesNotThrowIfHttpContextIsUnavailable()
-        {
-            var ac = new HttpContextAccessor() { HttpContext = null };
-
-            var initializer = new DomainNameRoleInstanceTelemetryInitializer(ac);
-
-            initializer.Initialize(new RequestTelemetry());
-        }
-
-        [Fact]
-        public void InitializeDoesNotThrowIfRequestTelemetryIsUnavailable()
-        {
-            var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
-
-            var initializer = new DomainNameRoleInstanceTelemetryInitializer(ac);
-
-            initializer.Initialize(new RequestTelemetry());
-        }
-
+        private const string TestListenerName = "TestListener";              
+        
         [Fact]
         public void RoleInstanceNameIsSetToDomainAndHost()
-        {
-            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), null);
-            var source = new DomainNameRoleInstanceTelemetryInitializer(contextAccessor);
+        {            
+            var source = new DomainNameRoleInstanceTelemetryInitializer();
             var requestTelemetry = new RequestTelemetry();
             source.Initialize(requestTelemetry);
 
@@ -68,9 +38,8 @@
 
         [Fact]
         public void ContextInitializerDoesNotOverrideMachineName()
-        {
-            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), null);
-            var source = new DomainNameRoleInstanceTelemetryInitializer(contextAccessor);
+        {            
+            var source = new DomainNameRoleInstanceTelemetryInitializer();
             var requestTelemetry = new RequestTelemetry();
             requestTelemetry.Context.Cloud.RoleInstance = "Test";
             requestTelemetry.Context.GetInternalContext().NodeName = "Test1";

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializerTests.cs
@@ -32,8 +32,7 @@
             }
 #endif
 
-            Assert.Equal(hostName, requestTelemetry.Context.Cloud.RoleInstance);
-            Assert.Equal(hostName, requestTelemetry.Context.GetInternalContext().NodeName);
+            Assert.Equal(hostName, requestTelemetry.Context.Cloud.RoleInstance);            
         }
 
         [Fact]
@@ -41,13 +40,9 @@
         {            
             var source = new DomainNameRoleInstanceTelemetryInitializer();
             var requestTelemetry = new RequestTelemetry();
-            requestTelemetry.Context.Cloud.RoleInstance = "Test";
-            requestTelemetry.Context.GetInternalContext().NodeName = "Test1";
-
+            requestTelemetry.Context.Cloud.RoleInstance = "Test";            
             source.Initialize(requestTelemetry);
-
-            Assert.Equal("Test", requestTelemetry.Context.Cloud.RoleInstance);
-            Assert.Equal("Test1", requestTelemetry.Context.GetInternalContext().NodeName);
+            Assert.Equal("Test", requestTelemetry.Context.Cloud.RoleInstance);            
         }
     }
 }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializerTests.cs
@@ -1,0 +1,84 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests.ContextInitializers
+{
+    using System;
+    using System.Globalization;
+    using System.Net;
+    using System.Net.NetworkInformation;
+    using Helpers;
+    using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.AspNetCore.Http;
+    using Xunit;
+
+    public class DomainNameRoleInstanceTelemetryInitializerTests
+    {
+        private const string TestListenerName = "TestListener";
+
+        [Fact]
+        public void InitializeThrowIfHttpContextAccessorIsNull()
+        {
+            Assert.ThrowsAny<ArgumentNullException>(() =>
+            {
+                var initializer = new DomainNameRoleInstanceTelemetryInitializer(null);
+            });
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowIfHttpContextIsUnavailable()
+        {
+            var ac = new HttpContextAccessor() { HttpContext = null };
+
+            var initializer = new DomainNameRoleInstanceTelemetryInitializer(ac);
+
+            initializer.Initialize(new RequestTelemetry());
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowIfRequestTelemetryIsUnavailable()
+        {
+            var ac = new HttpContextAccessor() { HttpContext = new DefaultHttpContext() };
+
+            var initializer = new DomainNameRoleInstanceTelemetryInitializer(ac);
+
+            initializer.Initialize(new RequestTelemetry());
+        }
+
+        [Fact]
+        public void RoleInstanceNameIsSetToDomainAndHost()
+        {
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), null);
+            var source = new DomainNameRoleInstanceTelemetryInitializer(contextAccessor);
+            var requestTelemetry = new RequestTelemetry();
+            source.Initialize(requestTelemetry);
+
+            string hostName = Dns.GetHostName();
+
+#if NET451 || NET46
+            string domainName = IPGlobalProperties.GetIPGlobalProperties().DomainName;
+            if (hostName.EndsWith(domainName, StringComparison.OrdinalIgnoreCase) == false)
+            {
+                hostName = string.Format(CultureInfo.InvariantCulture, "{0}.{1}", hostName, domainName);
+            }
+#endif
+
+            Assert.Equal(hostName, requestTelemetry.Context.Cloud.RoleInstance);
+            Assert.Equal(hostName, requestTelemetry.Context.GetInternalContext().NodeName);
+        }
+
+        [Fact]
+        public void ContextInitializerDoesNotOverrideMachineName()
+        {
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), null);
+            var source = new DomainNameRoleInstanceTelemetryInitializer(contextAccessor);
+            var requestTelemetry = new RequestTelemetry();
+            requestTelemetry.Context.Cloud.RoleInstance = "Test";
+            requestTelemetry.Context.GetInternalContext().NodeName = "Test1";
+
+            source.Initialize(requestTelemetry);
+
+            Assert.Equal("Test", requestTelemetry.Context.Cloud.RoleInstance);
+            Assert.Equal("Test1", requestTelemetry.Context.GetInternalContext().NodeName);
+        }
+    }
+}


### PR DESCRIPTION
Fix Issue #671  .
Brought back DomainNameRoleInstanceTelemetryInitializer 

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
