### PR TITLE
RequestTelemetry is not populated with HttpMethod which is obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 2.3.0
 - [Fix reading of instrumentation key from appsettings.json file when using AddApplicationInsightsTelemetry() extension to add ApplicationInsights ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/605)
 - [Bring back DomainNameRoleInstanceTelemetryInitializer without which NodeName and RoleInstance will be empty in Ubuntu](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/671)
+- [RequestTelemetry is no longer populated with HttpMethod which is obsolete.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/675)
 
 ## Version 2.3.0-beta2
 - [Update System.Net.Http version referred to 4.3.2 as older version has known security vulnerability. ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/666)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/ApplicationInsightsJavaScript.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/ApplicationInsightsJavaScript.cs
@@ -36,6 +36,7 @@
         /// <param name="telemetryConfiguration">The configuration instance to use.</param>
         /// <param name="serviceOptions">Service options instance to use.</param>
         /// <param name="httpContextAccessor">Http context accessor to use.</param>
+        /// <param name="encoder">Encoder used to encode user identity.</param>
         public JavaScriptSnippet(TelemetryConfiguration telemetryConfiguration,
             IOptions<ApplicationInsightsServiceOptions> serviceOptions,
             IHttpContextAccessor httpContextAccessor,

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -296,6 +296,7 @@
                 }
 
                 var exceptionTelemetry = new ExceptionTelemetry(exception);                
+                exceptionTelemetry.HandledAt = ExceptionHandledAt.Platform;
                 exceptionTelemetry.Context.GetInternalContext().SdkVersion = this.sdkVersion;
                 this.client.Track(exceptionTelemetry);
             }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -295,7 +295,7 @@
                     telemetry.Success = false;
                 }
 
-                var exceptionTelemetry = new ExceptionTelemetry(exception);                
+                var exceptionTelemetry = new ExceptionTelemetry(exception);
                 exceptionTelemetry.HandledAt = ExceptionHandledAt.Platform;
                 exceptionTelemetry.Context.GetInternalContext().SdkVersion = this.sdkVersion;
                 this.client.Track(exceptionTelemetry);

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -272,8 +272,7 @@
                 {
                     telemetry.Name = httpContext.Request.Method + " " + httpContext.Request.Path.Value;
                 }
-
-                telemetry.HttpMethod = httpContext.Request.Method;
+                
                 telemetry.Url = httpContext.Request.GetUri();
                 telemetry.Context.GetInternalContext().SdkVersion = this.sdkVersion;
                 this.client.TrackRequest(telemetry);
@@ -296,8 +295,7 @@
                     telemetry.Success = false;
                 }
 
-                var exceptionTelemetry = new ExceptionTelemetry(exception);
-                exceptionTelemetry.HandledAt = ExceptionHandledAt.Platform;
+                var exceptionTelemetry = new ExceptionTelemetry(exception);                
                 exceptionTelemetry.Context.GetInternalContext().SdkVersion = this.sdkVersion;
                 this.client.Track(exceptionTelemetry);
             }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
@@ -19,9 +19,10 @@
         private List<IApplicationInsightDiagnosticListener> diagnosticListeners;
         private bool isInitialized = false;
         private readonly object lockObject = new object();
-        private TelemetryConfiguration configuration;
 
-
+        /// <summary>
+        /// RequestTrackingTelemetryModule
+        /// </summary>
         public RequestTrackingTelemetryModule() : this(null)
         {            
         }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/RequestTrackingMiddlewareTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/RequestTrackingMiddlewareTest.cs
@@ -83,7 +83,7 @@
 
             HandleRequestEnd(context, 0);
 
-            Assert.Equal(1, sentTelemetry.Count);
+            Assert.Single(sentTelemetry);
             Assert.IsType<RequestTelemetry>(this.sentTelemetry.First());
 
             RequestTelemetry requestTelemetry = this.sentTelemetry.First() as RequestTelemetry;
@@ -108,7 +108,7 @@
 
             HandleRequestEnd(context, 0);
 
-            Assert.Equal(1, sentTelemetry.Count);
+            Assert.Single(sentTelemetry);
             Assert.IsType<RequestTelemetry>(this.sentTelemetry.First());
             RequestTelemetry requestTelemetry = sentTelemetry.First() as RequestTelemetry;
             Assert.NotNull(requestTelemetry.Url);
@@ -309,14 +309,13 @@
 
             HandleRequestEnd(context, 0);
 
-            Assert.Equal(1, sentTelemetry.Count);
+            Assert.Single(sentTelemetry);
             Assert.IsType<RequestTelemetry>(this.sentTelemetry.First());
             RequestTelemetry requestTelemetry = this.sentTelemetry.First() as RequestTelemetry;
             Assert.True(requestTelemetry.Duration.TotalMilliseconds >= 0);
             Assert.True(requestTelemetry.Success);
             Assert.Equal(CommonMocks.InstrumentationKey, requestTelemetry.Context.InstrumentationKey);
-            Assert.Equal("", requestTelemetry.Source);
-            Assert.Equal("POST", requestTelemetry.HttpMethod);
+            Assert.Equal("", requestTelemetry.Source);            
             Assert.Equal(CreateUri(HttpRequestScheme, HttpRequestHost, "/Test"), requestTelemetry.Url);
             Assert.NotEmpty(requestTelemetry.Context.GetInternalContext().SdkVersion);
             Assert.Contains(SdkVersionTestUtils.VersionPrefix, requestTelemetry.Context.GetInternalContext().SdkVersion);
@@ -341,8 +340,7 @@
             Assert.True(requestTelemetry.Duration.TotalMilliseconds >= 0);
             Assert.True(requestTelemetry.Success);
             Assert.Equal(CommonMocks.InstrumentationKey, requestTelemetry.Context.InstrumentationKey);
-            Assert.Equal("", requestTelemetry.Source);
-            Assert.Equal("GET", requestTelemetry.HttpMethod);
+            Assert.Equal("", requestTelemetry.Source);            
             Assert.Equal(CreateUri(HttpRequestScheme, HttpRequestHost, "/Test"), requestTelemetry.Url);
             Assert.NotEmpty(requestTelemetry.Context.GetInternalContext().SdkVersion);
             Assert.Contains(SdkVersionTestUtils.VersionPrefix, requestTelemetry.Context.GetInternalContext().SdkVersion);
@@ -369,8 +367,7 @@
             Assert.True(requestTelemetry.Duration.TotalMilliseconds >= 0);
             Assert.True(requestTelemetry.Success);
             Assert.Equal(CommonMocks.InstrumentationKey, requestTelemetry.Context.InstrumentationKey);
-            Assert.Equal("", requestTelemetry.Source);
-            Assert.Equal("GET", requestTelemetry.HttpMethod);
+            Assert.Equal("", requestTelemetry.Source);            
             Assert.Equal(CreateUri(HttpRequestScheme, HttpRequestHost, "/Test"), requestTelemetry.Url);
             Assert.NotEmpty(requestTelemetry.Context.GetInternalContext().SdkVersion);
             Assert.Contains(SdkVersionTestUtils.VersionPrefix, requestTelemetry.Context.GetInternalContext().SdkVersion);
@@ -390,14 +387,13 @@
 
             HandleRequestEnd(context, 0);
 
-            Assert.Equal(1, sentTelemetry.Count);
+            Assert.Single(sentTelemetry);
             Assert.IsType<RequestTelemetry>(this.sentTelemetry.First());
             RequestTelemetry requestTelemetry = this.sentTelemetry.First() as RequestTelemetry;
             Assert.True(requestTelemetry.Duration.TotalMilliseconds >= 0);
             Assert.True(requestTelemetry.Success);
             Assert.Equal(CommonMocks.InstrumentationKey, requestTelemetry.Context.InstrumentationKey);
-            Assert.Equal("", requestTelemetry.Source);
-            Assert.Equal("GET", requestTelemetry.HttpMethod);
+            Assert.Equal("", requestTelemetry.Source);            
             Assert.Equal(CreateUri(HttpRequestScheme, HttpRequestHost, "/Test"), requestTelemetry.Url);
             Assert.NotEmpty(requestTelemetry.Context.GetInternalContext().SdkVersion);
             Assert.Contains(SdkVersionTestUtils.VersionPrefix, requestTelemetry.Context.GetInternalContext().SdkVersion);


### PR DESCRIPTION
RequestTelemetry is not populated with HttpMethod which is obsolete. HttpMethod is already part of Name, so this information is redundant as well.

This makes asp.net core sdk in sync with web sdk.

Fix Issue #675 .
<Short description of the fix.>

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
