### PR TITLE
Fix a bug which caused Requests to fail when HostName was empty. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version 2.3.0
+- [Fix a bug which caused Requests to fail when Hostname was empty.] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/278)
 - [Fix reading of instrumentation key from appsettings.json file when using AddApplicationInsightsTelemetry() extension to add ApplicationInsights ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/605)
 - [Bring back DomainNameRoleInstanceTelemetryInitializer without which NodeName and RoleInstance will be empty in Ubuntu](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/671)
 - [RequestTelemetry is no longer populated with HttpMethod which is obsolete.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/675)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/HttpRequestExtensions.cs
@@ -16,6 +16,8 @@
         /// <returns>A New Uri object representing request Uri</returns>
         public static Uri GetUri(this HttpRequest request)
         {
+            string unknownHostName = "UNKNOWN-HOST";
+
             if (null == request)
             {
                 throw new ArgumentNullException("request");
@@ -26,16 +28,13 @@
                 throw new ArgumentException("Http request Scheme is not specified");
             }
 
-            if (false == request.Host.HasValue)
-            {
-                throw new ArgumentException("Http request Host is not specified");
-            }
-
+            string hostName = request.Host.HasValue ? request.Host.ToString() : unknownHostName;
+            
             var builder = new StringBuilder();
 
             builder.Append(request.Scheme)
                 .Append("://")
-                .Append(request.Host);
+                .Append(hostName);
 
             if (true == request.Path.HasValue)
             {

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/HttpRequestExtensionsTest.cs
@@ -11,14 +11,14 @@
     {
         const string ExpectedSchema = "http";
         const string ExpectedHostName = "randomhost";
+        const string ExpectedDefaultHostName = "unknown-host";
         const string ExpectedPath = "/path/path/";
         const string ExpectedQueryString = "?queryType=1";
 
         [Fact]
         public void TestGetUriThrowsExceptionOnNullRequestObject()
         {
-            Assert.Throws(
-                typeof(ArgumentNullException), 
+            Assert.Throws<ArgumentNullException>(
                 () =>
                 {
                     HttpRequestExtensions.GetUri(null);
@@ -30,8 +30,7 @@
         {
             var request = new DefaultHttpContext().Request;
 
-            var exception = Assert.Throws(
-                typeof(ArgumentException),
+            var exception = Assert.Throws<ArgumentException>(
                 () =>
                 {
                     HttpRequestExtensions.GetUri(request);
@@ -41,19 +40,15 @@
         }
 
         [Fact]
-        public void TestGetUriThrowsExceptionOnRequestObjectHostIsNotSpecified()
-        {
+        public void TestGetUriUsesDefaultHostNameOnRequestObjectHostIsNotSpecified()
+        {            
             var request = new DefaultHttpContext().Request;
             request.Scheme = ExpectedSchema;
 
-            var exception = Assert.Throws(
-                typeof(ArgumentException),
-                () =>
-                {
-                    HttpRequestExtensions.GetUri(request);
-                });
-
-            Assert.True(exception.Message.Contains("Host"), "Host is not mentioned in the exception");
+            var uri = HttpRequestExtensions.GetUri(request);
+            Assert.Equal(
+                new Uri(string.Format(CultureInfo.InvariantCulture, "{0}://{1}", ExpectedSchema, ExpectedDefaultHostName)),
+                uri);
         }
 
         [Fact]

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/HttpRequestExtensionsTest.cs
@@ -41,7 +41,7 @@
 
         [Fact]
         public void TestGetUriUsesDefaultHostNameOnRequestObjectHostIsNotSpecified()
-        {            
+        {
             var request = new DefaultHttpContext().Request;
             request.Scheme = ExpectedSchema;
 


### PR DESCRIPTION
Hostname will be set to a default name if no value exist

Fix Issue #278  .
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
