### PR TITLE
Change target framework for FunctionalTestUtils netcoreapp

### DIFF
--- a/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
+++ b/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.2</VersionPrefix>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>    
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>FunctionalTestUtils20</AssemblyName>    
     <PackageId>FunctionalTestUtils</PackageId>

--- a/test/FunctionalTestUtils20/HttpListenerObservableBase.cs
+++ b/test/FunctionalTestUtils20/HttpListenerObservableBase.cs
@@ -7,15 +7,20 @@
     using System.Reactive.Linq;
     using System.Reactive.Threading.Tasks;
     using System.Threading.Tasks;
+    using Xunit.Abstractions;
 
     public abstract class HttpListenerObservableBase<T> : IObservable<T>, IDisposable
     {
         private readonly HttpListener listener;
         private IObservable<T> stream;
+        private ITestOutputHelper output;
 
-        public HttpListenerObservableBase(string url)
+        public HttpListenerObservableBase(string url, ITestOutputHelper output)
         {
-            this.listener = new HttpListener();
+            this.output = output;
+
+            this.output.WriteLine(string.Format("{0}: HttpListenerObservableBase Constructor. Url is: {1}", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt"), url));
+            this.listener = new HttpListener();            
             this.listener.Prefixes.Add(url);
         }
 
@@ -24,12 +29,16 @@
             OnStart();
             if (this.stream != null)
             {
+                this.output.WriteLine(string.Format("{0}: HttpListenerObservableBase Start. Stream is not null. Stopping", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt")));
                 this.Stop();
+                this.output.WriteLine(string.Format("{0}: HttpListenerObservableBase Start. Stream is not null. Stop completed", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt")));
             }
 
             if (!this.listener.IsListening)
             {
+                this.output.WriteLine(string.Format("{0}: HttpListenerObservableBase Start. Listenet not already listening. Starting to listen", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt")));
                 this.listener.Start();
+                this.output.WriteLine(string.Format("{0}: HttpListenerObservableBase Start. Listenet not already listening. Started listening", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt")));
             }
 
             this.stream = this.CreateStream();

--- a/test/FunctionalTestUtils20/HttpListenerObservableBase.cs
+++ b/test/FunctionalTestUtils20/HttpListenerObservableBase.cs
@@ -36,9 +36,9 @@
 
             if (!this.listener.IsListening)
             {
-                this.output.WriteLine(string.Format("{0}: HttpListenerObservableBase Start. Listenet not already listening. Starting to listen", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt")));
+                this.output.WriteLine(string.Format("{0}: HttpListenerObservableBase Start. Listener not already listening. Starting to listen", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt")));
                 this.listener.Start();
-                this.output.WriteLine(string.Format("{0}: HttpListenerObservableBase Start. Listenet not already listening. Started listening", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt")));
+                this.output.WriteLine(string.Format("{0}: HttpListenerObservableBase Start. Listener not already listening. Started listening", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt")));
             }
 
             this.stream = this.CreateStream();

--- a/test/FunctionalTestUtils20/InProcessServer.cs
+++ b/test/FunctionalTestUtils20/InProcessServer.cs
@@ -49,7 +49,7 @@
 
             output.WriteLine(string.Format("{0}: Starting listener at: {1}", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt"), this.httpListenerConnectionString));
 
-            this.listener = new TelemetryHttpListenerObservable(this.httpListenerConnectionString);
+            this.listener = new TelemetryHttpListenerObservable(this.httpListenerConnectionString, this.output);
             try
             {
                 this.listener.Start();
@@ -107,7 +107,7 @@
             if (this.listener != null)
             {
                 output.WriteLine(string.Format("{0}: Stopping listener at: {1}", DateTime.Now.ToString("G"), this.httpListenerConnectionString));
-                this.listener.Stop();
+                this.listener.Stop();                
             }
         }
     }

--- a/test/FunctionalTestUtils20/InProcessServer.cs
+++ b/test/FunctionalTestUtils20/InProcessServer.cs
@@ -101,7 +101,10 @@
         {
             if (this.hostingEngine != null)
             {
+                this.output.WriteLine(string.Format("{0}:Disposing WebHost starting.....", DateTime.Now.ToString("G")));
                 this.hostingEngine.Dispose();
+                this.hostingEngine.WaitForShutdown();
+                this.output.WriteLine(string.Format("{0}:Disposing WebHost completed.", DateTime.Now.ToString("G")));
             }
 
             if (this.listener != null)

--- a/test/FunctionalTestUtils20/InProcessServer.cs
+++ b/test/FunctionalTestUtils20/InProcessServer.cs
@@ -102,9 +102,12 @@
             if (this.hostingEngine != null)
             {
                 this.output.WriteLine(string.Format("{0}:Disposing WebHost starting.....", DateTime.Now.ToString("G")));
-                this.hostingEngine.Dispose();
-                this.hostingEngine.WaitForShutdown();
+                this.hostingEngine.Dispose();                
                 this.output.WriteLine(string.Format("{0}:Disposing WebHost completed.", DateTime.Now.ToString("G")));
+            }
+            else
+            {
+                this.output.WriteLine(string.Format("{0}: Hosting engine is null.", DateTime.Now.ToString("G")));
             }
 
             if (this.listener != null)

--- a/test/FunctionalTestUtils20/TelemetryHttpListenerObservable.cs
+++ b/test/FunctionalTestUtils20/TelemetryHttpListenerObservable.cs
@@ -10,12 +10,13 @@
     using System.Text;
     using System.Threading.Tasks;
     using AI;
+    using Xunit.Abstractions;
 
     public class TelemetryHttpListenerObservable : HttpListenerObservableBase<Envelope>
     {        
         public bool FailureDetected { get; set; }
 
-        public TelemetryHttpListenerObservable(string url) : base(url)
+        public TelemetryHttpListenerObservable(string url, ITestOutputHelper output) : base(url, output)
         {
         }        
 

--- a/test/FunctionalTestUtils20/TelemetryTestsBase.cs
+++ b/test/FunctionalTestUtils20/TelemetryTestsBase.cs
@@ -146,7 +146,7 @@
                     if (request != null)
                     {
                         var data = ((TelemetryItem<RequestData>)request).data.baseData;
-                        builder.AppendLine($"{request.ToString()} - {data.url} - {data.duration} - {data.id} - {data.name} - {data.success} - {data.responseCode}");
+                        builder.AppendLine($"{request.ToString()} - {data.url} - {((TelemetryItem<RequestData>)request).time} - {data.duration} - {data.id} - {data.name} - {data.success} - {data.responseCode}");
                     }
                     else
                     {
@@ -166,7 +166,7 @@
                             }
                             else
                             {
-                                builder.AppendLine($"{telemetry.ToString()} - {telemetry.name}");
+                                builder.AppendLine($"{telemetry.ToString()} - {telemetry.time}- {telemetry.name}");
                             }
                         }
                     }

--- a/test/FunctionalTestUtils20/TelemetryTestsBase.cs
+++ b/test/FunctionalTestUtils20/TelemetryTestsBase.cs
@@ -167,7 +167,19 @@
                             else
                             {
                                 TelemetryItem<MetricData> metric = telemetry as TelemetryItem<MetricData>;
-                                builder.AppendLine($"{telemetry.ToString()} - {telemetry.time}- {metric.name} - {metric.data}");
+                                if (metric != null)
+                                {
+                                    var data = ((TelemetryItem<MetricData>)metric).data.baseData;
+                                    builder.AppendLine($"{metric.ToString()} - {metric.data}- {metric.name} - {data.metrics.Count}");
+                                    foreach (var metricVal in data.metrics)
+                                    {
+                                        builder.AppendLine($"{metricVal.name} {metricVal.value}");
+                                    }
+                                }     
+                                else
+                                {
+                                    builder.AppendLine($"{telemetry.ToString()} - {telemetry.time}");
+                                }
                             }
                         }
                     }

--- a/test/FunctionalTestUtils20/TelemetryTestsBase.cs
+++ b/test/FunctionalTestUtils20/TelemetryTestsBase.cs
@@ -136,9 +136,9 @@
             {
                 TelemetryItem<RemoteDependencyData> dependency = telemetry as TelemetryItem<RemoteDependencyData>;
                 if (dependency != null)
-                {
+                {                    
                     var data = ((TelemetryItem<RemoteDependencyData>)dependency).data.baseData;
-                    builder.AppendLine($"{dependency.ToString()} - {data.data} - {data.duration} - {data.id} - {data.name} - {data.resultCode} - {data.success} - {data.target} - {data.type}");
+                    builder.AppendLine($"{dependency.ToString()} - {data.data} - {((TelemetryItem<RemoteDependencyData>)dependency).time} - {data.duration} - {data.id} - {data.name} - {data.resultCode} - {data.success} - {data.target} - {data.type}");
                 }
                 else
                 {

--- a/test/FunctionalTestUtils20/TelemetryTestsBase.cs
+++ b/test/FunctionalTestUtils20/TelemetryTestsBase.cs
@@ -166,7 +166,8 @@
                             }
                             else
                             {
-                                builder.AppendLine($"{telemetry.ToString()} - {telemetry.time}- {telemetry.name}");
+                                TelemetryItem<MetricData> metric = telemetry as TelemetryItem<MetricData>;
+                                builder.AppendLine($"{telemetry.ToString()} - {telemetry.time}- {metric.name} - {metric.data}");
                             }
                         }
                     }

--- a/test/MVCFramework20.FunctionalTests/Startup.cs
+++ b/test/MVCFramework20.FunctionalTests/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.ApplicationInsights.Channel;
 using FunctionalTestUtils;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 
 namespace MVCFramework20.FunctionalTests
 {
@@ -26,10 +27,13 @@ namespace MVCFramework20.FunctionalTests
             var endpointAddress = new EndpointAddress();
             services.AddSingleton<EndpointAddress>(endpointAddress);
 
-            var builder = new ConfigurationBuilder();
-            builder.AddApplicationInsightsSettings(instrumentationKey: "Foo", endpointAddress: endpointAddress.ConnectionString, developerMode: true);
-            services.AddApplicationInsightsTelemetry(builder.Build());
+            ApplicationInsightsServiceOptions applicationInsightsOptions = new ApplicationInsightsServiceOptions();
+            applicationInsightsOptions.AddAutoCollectedMetricExtractor = false;
+            applicationInsightsOptions.DeveloperMode = true;
+            applicationInsightsOptions.EndpointAddress = endpointAddress.ConnectionString;
+            applicationInsightsOptions.InstrumentationKey = "foo";
 
+            services.AddApplicationInsightsTelemetry(applicationInsightsOptions);
             services.AddMvc();
         }
 

--- a/test/WebApi20.FunctionalTests/FunctionalTest/MultipleWebHostsTests.cs
+++ b/test/WebApi20.FunctionalTests/FunctionalTest/MultipleWebHostsTests.cs
@@ -138,7 +138,7 @@ namespace WebApi20.FunctionalTests20.FunctionalTest
 
             Assert.NotNull(activeConfig.TelemetryChannel);
 
-            using (var listener = new TelemetryHttpListenerObservable(activeConfig.TelemetryChannel.EndpointAddress))
+            using (var listener = new TelemetryHttpListenerObservable(activeConfig.TelemetryChannel.EndpointAddress, this.output))
             {
                 listener.Start();
 


### PR DESCRIPTION
..without which Xunit runner was throwing fatal exception.
2018-05-08T21:08:10.5709157Z [xUnit.net 00:00:00.2280923] Catastrophic failure: System.TypeLoadException: Could not load type 'System.Runtime.Remoting.Channels.IChannel' from assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.

Fix Issue # .
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
