### PR TITLE
Fixed a bug so that AddAutoCollectedMetricExtractor flag is respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Fix reading of instrumentation key from appsettings.json file when using AddApplicationInsightsTelemetry() extension to add ApplicationInsights ](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/605)
 - [Bring back DomainNameRoleInstanceTelemetryInitializer without which NodeName and RoleInstance will be empty in Ubuntu](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/671)
 - [RequestTelemetry is no longer populated with HttpMethod which is obsolete.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/675)
+- Fixed a bug which caused AutoCollectedMetricExtractor flag to be always true.
 - Updated Web/Base SDK version dependency to 2.6.1
 
 ## Version 2.3.0-beta2

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -117,6 +117,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 o.EndpointAddress = options.EndpointAddress;
                 o.InstrumentationKey = options.InstrumentationKey;
                 o.EnableHeartbeat = options.EnableHeartbeat;
+                o.AddAutoCollectedMetricExtractor = options.AddAutoCollectedMetricExtractor;
             });
             return services;
         }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -794,8 +794,12 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             [Fact]
             public static void DoesNotAddAutoCollectedMetricsExtractorToConfigurationIfExplicitlyControlledThroughParameter()
             {
-                Action<ApplicationInsightsServiceOptions> serviceOptions = options => options.AddAutoCollectedMetricExtractor = false;
-                var services = CreateServicesAndAddApplicationinsightsTelemetry(null, "http://localhost:1234/v2/track/", serviceOptions, false);
+                var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
+                ApplicationInsightsServiceOptions serviceOptions = new ApplicationInsightsServiceOptions();
+                serviceOptions.AddAutoCollectedMetricExtractor = false;
+
+                services.AddApplicationInsightsTelemetry(serviceOptions);
+
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
                 var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
                 var metricExtractorProcessorCount = GetTelemetryProcessorsCountInConfiguration<AutocollectedMetricsExtractor>(telemetryConfiguration);


### PR DESCRIPTION
AddAutoCollectedMetricExtractor  was always set to default (true) value, and user input was not respected. This fixes that, and modifies the unit test which should have caught this.

This issue manifested as FuncTest failures (random ones), when telemetry from AddAutoCollectedMetricExtractor  caused telemetry count to be incorrect. This fix should stabilize those func tests now.

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
