### PR TITLE
Add retry logic if FakeListener cannot be started. There are random t…

### DIFF
--- a/test/FunctionalTestUtils20/InProcessServer.cs
+++ b/test/FunctionalTestUtils20/InProcessServer.cs
@@ -43,22 +43,69 @@
             var machineName = "localhost";
             this.url = "http://" + machineName + ":" + random.Next(5000, 14000).ToString();
 
-            output.WriteLine(string.Format("{0}: Launching application at: {1}", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt"), this.url));
+            this.httpListenerConnectionString = LauchApplicationAndStartListener(assemblyName);
+        }
 
-            this.httpListenerConnectionString = this.Start(assemblyName);
+        private string LauchApplicationAndStartListener(string assemblyName)
+        {
+            string listenerConnectionString = "";
+            bool listenerStarted = false;
+            int retryCount = 1;
+            while (retryCount <= 3)
+            {
+                output.WriteLine(string.Format("{0}: Attempt {1} to StartApplication", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt"), retryCount));
+                listenerConnectionString = StartApplication(assemblyName);
+                listenerStarted = StartListener(listenerConnectionString);
+                if(listenerStarted)
+                {
+                    break;
+                }
+                else
+                {
+                    StopApplication();
+                }
+                retryCount++;
+            }
 
+            if(!listenerStarted)
+            {
+                throw new Exception("Unable to start listener after 3 attempts. Failing. Read logs above for details about the exceptions.");
+            }
+            
+            return listenerConnectionString;
+        }
+
+        private bool StartListener(string listenerConnectionString)
+        {
             output.WriteLine(string.Format("{0}: Starting listener at: {1}", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt"), this.httpListenerConnectionString));
 
-            this.listener = new TelemetryHttpListenerObservable(this.httpListenerConnectionString, this.output);
+            this.listener = new TelemetryHttpListenerObservable(listenerConnectionString, this.output);
             try
             {
                 this.listener.Start();
                 output.WriteLine(string.Format("{0}: Started listener", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt")));
             }
-            catch(HttpListenerException ex)
+            catch (HttpListenerException ex)
             {
                 output.WriteLine(string.Format("{0}: Error starting listener.ErrorCode {1} Native Code {2}", DateTime.Now.ToString("G"), ex.ErrorCode, ex.NativeErrorCode));
-                throw ex;
+                return false;
+            }
+
+            return true;
+        }
+        private string StartApplication(string assemblyName)
+        {
+            output.WriteLine(string.Format("{0}: Launching application at: {1}", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt"), this.url));
+            return this.Start(assemblyName); ;
+        }
+
+        private void StopApplication()
+        {
+            if (this.hostingEngine != null)
+            {
+                this.output.WriteLine(string.Format("{0}:Disposing WebHost starting.....", DateTime.Now.ToString("G")));
+                this.hostingEngine.Dispose();
+                this.output.WriteLine(string.Format("{0}:Disposing WebHost completed.", DateTime.Now.ToString("G")));
             }
         }
 


### PR DESCRIPTION
…ests failures when listener cannot start. This should stabilize them as the likely reason why a listener creation fails is because some previous test has not proerly released listener ports.

Fix Issue # .
<Short description of the fix.>

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
