### PR TITLE
Default TelemetryProcessors to be added on DefaultSink instead of on common pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## Version 2.5.0-beta2
-ComVisible attribute is set to false for the project for compliance reasons.
+- ComVisible attribute is set to false for the project for compliance reasons.
+Applicable if using additional Sinks to forward telemetry to:
+  - [Default TelemetryProcessors are added to the DefaultSink instead of common TelemetryProcessor pipeline.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/752)
+  - [TelemetryProcessors added via AddTelemetryProcesor extension method are added to the DefaultSink instead of common TelemetryProcessor pipeline.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/752)
+
 
 ## Version 2.5.0-beta1
 - [Adds opt-in support for W3C distributed tracing standard](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/735)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Extensions.DependencyInjection
             if (this.telemetryProcessorFactories.Any())
             {
                 foreach (ITelemetryProcessorFactory processorFactory in this.telemetryProcessorFactories)
-                {
-                    configuration.TelemetryProcessorChainBuilder.Use(processorFactory.Create);
+                {                    
+                    configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder.Use(processorFactory.Create);
                 }                
             }
 
@@ -95,6 +95,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 this.EnableW3CHeaders(configuration);
             }
 
+            configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder.Build();
             configuration.TelemetryProcessorChainBuilder.Build();            
 
             if (this.applicationInsightsServiceOptions.DeveloperMode != null)
@@ -138,7 +139,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (quickPulseModule != null)
                 {                    
                     QuickPulseTelemetryProcessor processor = null;
-                    configuration.TelemetryProcessorChainBuilder.Use((next) =>
+                    configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder.Use((next) =>
                     {
                         processor = new QuickPulseTelemetryProcessor(next);
                         quickPulseModule.RegisterTelemetryProcessor(processor);
@@ -156,8 +157,8 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             if (this.applicationInsightsServiceOptions.EnableAdaptiveSampling)
             {
-                configuration.TelemetryProcessorChainBuilder.UseAdaptiveSampling(5, excludedTypes: "Event");
-                configuration.TelemetryProcessorChainBuilder.UseAdaptiveSampling(5, includedTypes: "Event");
+                configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder.UseAdaptiveSampling(5, excludedTypes: "Event");
+                configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder.UseAdaptiveSampling(5, includedTypes: "Event");
             }
         }
 
@@ -165,7 +166,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             if (this.applicationInsightsServiceOptions.AddAutoCollectedMetricExtractor)
             {
-                configuration.TelemetryProcessorChainBuilder.Use(next => new AutocollectedMetricsExtractor(next));
+                configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder.Use(next => new AutocollectedMetricsExtractor(next));
             }
         }
 


### PR DESCRIPTION
Fix Issue #752 


- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
