### PR TITLE
Fix duplicated request telemetry when multiple hosts run in the same process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.6.0-beta3
+- [Fix: Do not track requests by each host in the process](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/621)
+
 ## Version 2.6.0-beta2
 - Updated Web/Base SDK version dependency to 2.9.0-beta2
 

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,5 +5,4 @@
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="applicationinsights" value="https://www.myget.org/F/applicationinsights/api/v3/index.json" />
   </packageSources>
-  <disabledPackageSources />
 </configuration>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -38,7 +38,7 @@
         private readonly bool injectResponseHeaders;
         private readonly bool trackExceptions;
         private readonly bool enableW3CHeaders;
-
+        private static readonly ActiveSubsciptionManager SubscriptionManager = new ActiveSubsciptionManager();
         private const string ActivityCreatedByHostingDiagnosticListener = "ActivityCreatedByHostingDiagnosticListener";
 
         /// <summary>
@@ -49,13 +49,24 @@
         /// <param name="injectResponseHeaders">Flag that indicates that response headers should be injected.</param>
         /// <param name="trackExceptions">Flag that indicates that exceptions should be tracked.</param>
         /// <param name="enableW3CHeaders">Flag that indicates that W3C header parsing should be enabled.</param>
-        public HostingDiagnosticListener(TelemetryClient client, IApplicationIdProvider applicationIdProvider, bool injectResponseHeaders, bool trackExceptions, bool enableW3CHeaders)
+        public HostingDiagnosticListener(
+            TelemetryClient client, 
+            IApplicationIdProvider applicationIdProvider, 
+            bool injectResponseHeaders, 
+            bool trackExceptions, 
+            bool enableW3CHeaders)
         {
             this.client = client ?? throw new ArgumentNullException(nameof(client));
             this.applicationIdProvider = applicationIdProvider;
             this.injectResponseHeaders = injectResponseHeaders;
             this.trackExceptions = trackExceptions;
             this.enableW3CHeaders = enableW3CHeaders;
+        }
+
+        /// <inheritdoc />
+        public void OnSubscribe()
+        {
+            SubscriptionManager.Attach(this);
         }
 
         /// <inheritdoc/>
@@ -78,6 +89,15 @@
         {
             if (this.client.IsEnabled())
             {
+                // It's possible to host multiple apps (ASP.NET Core or generic hosts) in the same process
+                // Each of this apps has it's own DependencyTrackingModule and corresponding Http listener.
+                // We should ignore events for all of them except one
+                if (!SubscriptionManager.IsActive(this))
+                {
+                    AspNetCoreEventSource.Instance.NotActiveListenerNoTracking("Microsoft.AspNetCore.Hosting.HttpRequestIn.Start", Activity.Current?.Id);
+                    return;
+                }
+
                 if (Activity.Current == null)
                 {
                     AspNetCoreEventSource.Instance.LogHostingDiagnosticListenerOnHttpRequestInStartActivityNull();
@@ -170,6 +190,16 @@
         {
             if (this.client.IsEnabled() && !IsAspNetCore20)
             {
+                // It's possible to host multiple apps (ASP.NET Core or generic hosts) in the same process
+                // Each of this apps has it's own DependencyTrackingModule and corresponding Http listener.
+                // We should ignore events for all of them except one
+                if (!SubscriptionManager.IsActive(this))
+                {
+                    AspNetCoreEventSource.Instance.NotActiveListenerNoTracking(
+                        "Microsoft.AspNetCore.Hosting.BeginRequest", Activity.Current?.Id);
+                    return;
+                }
+
                 var activity = new Activity(ActivityCreatedByHostingDiagnosticListener);
                 var isActivityCreatedFromRequestIdHeader = false;
 
@@ -374,6 +404,16 @@
         {
             if (this.client.IsEnabled())
             {
+                // It's possible to host multiple apps (ASP.NET Core or generic hosts) in the same process
+                // Each of this apps has it's own DependencyTrackingModule and corresponding Http listener.
+                // We should ignore events for all of them except one
+                if (!SubscriptionManager.IsActive(this))
+                {
+                    AspNetCoreEventSource.Instance.NotActiveListenerNoTracking(
+                        "EndRequest", Activity.Current?.Id);
+                    return;
+                }
+
                 var telemetry = httpContext?.Features.Get<RequestTelemetry>();
 
                 if (telemetry == null)
@@ -415,6 +455,16 @@
         {
             if (this.trackExceptions && this.client.IsEnabled())
             {
+                // It's possible to host multiple apps (ASP.NET Core or generic hosts) in the same process
+                // Each of this apps has it's own DependencyTrackingModule and corresponding Http listener.
+                // We should ignore events for all of them except one
+                if (!SubscriptionManager.IsActive(this))
+                {
+                    AspNetCoreEventSource.Instance.NotActiveListenerNoTracking(
+                        "Exception", Activity.Current?.Id);
+                    return;
+                }
+
                 var telemetry = httpContext?.Features.Get<RequestTelemetry>();
                 if (telemetry != null)
                 {
@@ -503,6 +553,11 @@
 
             appId = appIds[0];
             return true;
+        }
+
+        public void Dispose()
+        {
+            SubscriptionManager.Detach(this);
         }
     }
 #pragma warning restore 612, 618

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -90,7 +90,7 @@
             if (this.client.IsEnabled())
             {
                 // It's possible to host multiple apps (ASP.NET Core or generic hosts) in the same process
-                // Each of this apps has it's own DependencyTrackingModule and corresponding Http listener.
+                // Each of this apps has it's own HostingDiagnosticListener and corresponding Http listener.
                 // We should ignore events for all of them except one
                 if (!SubscriptionManager.IsActive(this))
                 {
@@ -191,7 +191,7 @@
             if (this.client.IsEnabled() && !IsAspNetCore20)
             {
                 // It's possible to host multiple apps (ASP.NET Core or generic hosts) in the same process
-                // Each of this apps has it's own DependencyTrackingModule and corresponding Http listener.
+                // Each of this apps has it's own HostingDiagnosticListener and corresponding Http listener.
                 // We should ignore events for all of them except one
                 if (!SubscriptionManager.IsActive(this))
                 {
@@ -405,7 +405,7 @@
             if (this.client.IsEnabled())
             {
                 // It's possible to host multiple apps (ASP.NET Core or generic hosts) in the same process
-                // Each of this apps has it's own DependencyTrackingModule and corresponding Http listener.
+                // Each of this apps has it's own HostingDiagnosticListener and corresponding Http listener.
                 // We should ignore events for all of them except one
                 if (!SubscriptionManager.IsActive(this))
                 {
@@ -456,7 +456,7 @@
             if (this.trackExceptions && this.client.IsEnabled())
             {
                 // It's possible to host multiple apps (ASP.NET Core or generic hosts) in the same process
-                // Each of this apps has it's own DependencyTrackingModule and corresponding Http listener.
+                // Each of this apps has it's own HostingDiagnosticListener and corresponding Http listener.
                 // We should ignore events for all of them except one
                 if (!SubscriptionManager.IsActive(this))
                 {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/IApplicationInsightDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/IApplicationInsightDiagnosticListener.cs
@@ -1,13 +1,20 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
 {
+    using System;
+
     /// <summary>
     /// Base diagnostic listener type for Application Insight
     /// </summary>
-    internal interface IApplicationInsightDiagnosticListener
+    internal interface IApplicationInsightDiagnosticListener : IDisposable
     {
         /// <summary>
         /// Gets a value indicating which listener this instance should be subscribed to
         /// </summary>
         string ListenerName { get; }
+
+        /// <summary>
+        /// Notifies listener that it is subscribed to DiagnosticSource
+        /// </summary>
+        void OnSubscribe();
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs
@@ -35,6 +35,11 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
             }
         }
 
+        /// <inheritdoc />
+        public void OnSubscribe()
+        {
+        }
+
         private string GetNameFromRouteContext(IRouteData routeData)
         {
             string name = null;
@@ -91,6 +96,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
             }
 
             return name;
+        }
+
+        public void Dispose()
+        {
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetEventSource.cs
@@ -146,6 +146,16 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             this.WriteEvent(12, this.ApplicationName);
         }
 
+        [Event(
+            13,
+            Keywords = Keywords.Diagnostics,
+            Message = "Not tracking operation for event = '{0}', id = '{1}', lisener is not active.",
+            Level = EventLevel.Verbose)]
+        public void NotActiveListenerNoTracking(string evntName, string activityId, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(13, evntName, activityId, this.ApplicationName);
+        }
+
         /// <summary>
         /// Keywords for the AspNetEventSource.
         /// </summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace Microsoft.ApplicationInsights.AspNetCore
 {
     using System;
@@ -10,7 +8,6 @@ namespace Microsoft.ApplicationInsights.AspNetCore
     using Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
 
     /// <summary>
     /// Telemetry module tracking requests using Diagnostic Listeners.

--- a/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace Microsoft.ApplicationInsights.AspNetCore
 {
     using System;
@@ -8,6 +10,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore
     using Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
 
     /// <summary>
     /// Telemetry module tracking requests using Diagnostic Listeners.
@@ -59,8 +62,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore
                     {
                         this.telemetryClient = new TelemetryClient(configuration);
 
-                        this.diagnosticListeners.Add
-                            (new HostingDiagnosticListener(
+                        this.diagnosticListeners.Add(new HostingDiagnosticListener(
                             this.telemetryClient,
                             this.applicationIdProvider,
                             this.CollectionOptions.InjectResponseHeaders,
@@ -92,6 +94,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore
                 if (applicationInsightDiagnosticListener.ListenerName == value.Name)
                 {
                     subs.Add(value.SubscribeWithAdapter(applicationInsightDiagnosticListener));
+                    applicationInsightDiagnosticListener.OnSubscribe();
                 }
             }
         }
@@ -128,6 +131,11 @@ namespace Microsoft.ApplicationInsights.AspNetCore
             foreach (var subscription in subs)
             {
                 subscription.Dispose();
+            }
+
+            foreach (var listener in this.diagnosticListeners)
+            {
+                listener.Dispose();
             }
         }
     }

--- a/test/FunctionalTestUtils20/TelemetryTestsBase.cs
+++ b/test/FunctionalTestUtils20/TelemetryTestsBase.cs
@@ -8,9 +8,6 @@
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using System.Text;
-    using System.Text.RegularExpressions;
-    using System.Threading;
-    using System.Threading.Tasks;
     using AI;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.Extensions.DependencyInjection;
@@ -138,7 +135,7 @@
 
             using (HttpClient httpClient = new HttpClient(httpClientHandler, true))
             {
-                this.output.WriteLine(string.Format("{0}: Executing request: {1}", DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt"), requestPath));
+                this.output.WriteLine($"{DateTime.Now:MM/dd/yyyy hh:mm:ss.fff tt}: Executing request: {requestPath}");
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestPath);
                 if (headers != null)
                 {
@@ -150,7 +147,7 @@
 
                 var task = httpClient.SendAsync(request);
                 task.Wait(TestListenerTimeoutInMs);
-                this.output.WriteLine(string.Format("{0:MM/dd/yyyy hh:mm:ss.fff tt}: Ended request: {1}", DateTime.Now, requestPath));
+                this.output.WriteLine($"{DateTime.Now:MM/dd/yyyy hh:mm:ss.fff tt}: Ended request: {requestPath}");
 
                 return task.Result;
             }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/ExceptionTrackingMiddlewareTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/ExceptionTrackingMiddlewareTest.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners;
-using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.ApplicationInsights.AspNetCore.Tests.Helpers;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
@@ -16,34 +15,39 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests
         [Fact]
         public void InvokeTracksExceptionThrownByNextMiddlewareAsHandledByPlatform()
         {
-            var middleware = new HostingDiagnosticListener(
+            using (var middleware = new HostingDiagnosticListener(
                 CommonMocks.MockTelemetryClient(telemetry => this.sentTelemetry = telemetry),
                 CommonMocks.GetMockApplicationIdProvider(),
                 injectResponseHeaders: true,
                 trackExceptions: true,
-                enableW3CHeaders:false);
+                enableW3CHeaders: false))
+            {
+                middleware.OnSubscribe();
+                middleware.OnHostingException(null, null);
 
-            middleware.OnHostingException(null, null);
-
-            Assert.NotNull(sentTelemetry);
-            Assert.IsType<ExceptionTelemetry>(sentTelemetry);
-            Assert.Equal(ExceptionHandledAt.Platform, ((ExceptionTelemetry)sentTelemetry).HandledAt);
+                Assert.NotNull(sentTelemetry);
+                Assert.IsType<ExceptionTelemetry>(sentTelemetry);
+                Assert.Equal(ExceptionHandledAt.Platform, ((ExceptionTelemetry) sentTelemetry).HandledAt);
+            }
         }
 
         [Fact]
         public void SdkVersionIsPopulatedByMiddleware()
         {
-            var middleware = new HostingDiagnosticListener(
-                CommonMocks.MockTelemetryClient(telemetry => this.sentTelemetry = telemetry), 
+            using (var middleware = new HostingDiagnosticListener(
+                CommonMocks.MockTelemetryClient(telemetry => this.sentTelemetry = telemetry),
                 CommonMocks.GetMockApplicationIdProvider(),
                 injectResponseHeaders: true,
                 trackExceptions: true,
-                enableW3CHeaders: false);
+                enableW3CHeaders: false))
+            {
+                middleware.OnSubscribe();
+                middleware.OnHostingException(null, null);
 
-            middleware.OnHostingException(null, null);
-
-            Assert.NotEmpty(sentTelemetry.Context.GetInternalContext().SdkVersion);
-            Assert.Contains(SdkVersionTestUtils.VersionPrefix, sentTelemetry.Context.GetInternalContext().SdkVersion);
+                Assert.NotEmpty(sentTelemetry.Context.GetInternalContext().SdkVersion);
+                Assert.Contains(SdkVersionTestUtils.VersionPrefix,
+                    sentTelemetry.Context.GetInternalContext().SdkVersion);
+            }
         }
     }
 }


### PR DESCRIPTION
Fix Issue #621

ServiceFabric supports running multiple apps on the same host. Each app has its own AppInsights pipeline configured. i.e. there are multiple active dependency collectors and diagnostics listeners. Each of them receives even about dependency calls and tracks duplicates.

This change allows only one listener to be 'active': i.e. track telemetry.
When it is disposed, a new active listener is chosen between survivors.

See also https://github.com/Microsoft/ApplicationInsights-dotnet-server/pull/1013 which fixes the issue for dependencies.

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
