### PR TITLE
Do not prevent correlation headers injection on localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.6.0-beta3
+- [Fix: Correlation doesn't work for localhost](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1120)
+
 ## Version 2.6.0-beta2
 - Updated Web/Base SDK version dependency to 2.9.0-beta2
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -151,13 +151,19 @@
                 services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>();
                 services.ConfigureTelemetryModule<DependencyTrackingTelemetryModule>((module, o) =>
                 {
-                    var excludedDomains = module.ExcludeComponentCorrelationHttpHeadersOnDomains;
-                    excludedDomains.Add("core.windows.net");
-                    excludedDomains.Add("core.chinacloudapi.cn");
-                    excludedDomains.Add("core.cloudapi.de");
-                    excludedDomains.Add("core.usgovcloudapi.net");
-                    excludedDomains.Add("localhost");
-                    excludedDomains.Add("127.0.0.1");
+                    module.EnableLegacyCorrelationHeadersInjection =
+                        o.DependencyCollectionOptions.EnableLegacyCorrelationHeadersInjection;
+
+                    if (module.EnableLegacyCorrelationHeadersInjection)
+                    {
+                        var excludedDomains = module.ExcludeComponentCorrelationHttpHeadersOnDomains;
+                        excludedDomains.Add("core.windows.net");
+                        excludedDomains.Add("core.chinacloudapi.cn");
+                        excludedDomains.Add("core.cloudapi.de");
+                        excludedDomains.Add("core.usgovcloudapi.net");
+                        excludedDomains.Add("localhost");
+                        excludedDomains.Add("127.0.0.1");
+                    }
 
                     var includedActivities = module.IncludeDiagnosticSourceActivities;
                     includedActivities.Add("Microsoft.Azure.EventHubs");

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -154,13 +154,14 @@
                     module.EnableLegacyCorrelationHeadersInjection =
                         o.DependencyCollectionOptions.EnableLegacyCorrelationHeadersInjection;
 
+                    var excludedDomains = module.ExcludeComponentCorrelationHttpHeadersOnDomains;
+                    excludedDomains.Add("core.windows.net");
+                    excludedDomains.Add("core.chinacloudapi.cn");
+                    excludedDomains.Add("core.cloudapi.de");
+                    excludedDomains.Add("core.usgovcloudapi.net");
+
                     if (module.EnableLegacyCorrelationHeadersInjection)
                     {
-                        var excludedDomains = module.ExcludeComponentCorrelationHttpHeadersOnDomains;
-                        excludedDomains.Add("core.windows.net");
-                        excludedDomains.Add("core.chinacloudapi.cn");
-                        excludedDomains.Add("core.cloudapi.de");
-                        excludedDomains.Add("core.usgovcloudapi.net");
                         excludedDomains.Add("localhost");
                         excludedDomains.Add("127.0.0.1");
                     }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNetCore.Extensions
 {
     using System.Reflection;
+    using Microsoft.ApplicationInsights.DependencyCollector;
 
     /// <summary>
     /// Application Insights service options defines the custom behavior of the features to add, as opposed to the default selection of features obtained from Application Insights.
@@ -9,7 +10,7 @@
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApplicationInsightsServiceOptions" /> class.
-        /// Application Insights service options that controlls the default behavior of application insights features.
+        /// Application Insights service options that controls the default behavior of application insights features.
         /// </summary>
         public ApplicationInsightsServiceOptions()
         {
@@ -20,6 +21,7 @@
             this.EnableHeartbeat = true;
             this.AddAutoCollectedMetricExtractor = true;
             this.RequestCollectionOptions = new RequestCollectionOptions();
+            this.DependencyCollectionOptions = new DependencyCollectionOptions();
             this.ApplicationVersion = Assembly.GetEntryAssembly()?.GetName().Version.ToString();
         }
 
@@ -80,5 +82,11 @@
         /// Gets <see cref="RequestCollectionOptions"/> that allow to manage <see cref="RequestTrackingTelemetryModule"/>
         /// </summary>
         public RequestCollectionOptions RequestCollectionOptions { get; }
+
+        /// <summary>
+        /// Gets <see cref="DependencyCollectionOptions"/> that allow to manage <see cref="DependencyTrackingTelemetryModule"/>
+        /// </summary>
+        public DependencyCollectionOptions DependencyCollectionOptions { get; }
+      
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DependencyCollectionOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DependencyCollectionOptions.cs
@@ -1,0 +1,21 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Extensions
+{
+    /// <summary>
+    /// Default collection options define the custom behavior or non-default features of dependency collection.
+    /// </summary>
+    public class DependencyCollectionOptions
+    {
+        /// <summary>
+        /// Creates new instance of <see cref="DependencyCollectionOptions"/> class and fills default values.
+        /// </summary>
+        public DependencyCollectionOptions()
+        {
+            EnableLegacyCorrelationHeadersInjection = false;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable legacy (x-ms*) correlation headers injection.
+        /// </summary>
+        public bool EnableLegacyCorrelationHeadersInjection { get; set; }
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/RequestCollectionOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/RequestCollectionOptions.cs
@@ -1,5 +1,8 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNetCore.Extensions
 {
+    /// <summary>
+    /// Request collection options define the custom behavior or non-default features of request collection.
+    /// </summary>
     public class RequestCollectionOptions
     {
         /// <summary>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -526,7 +526,9 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var dependencyModule = modules.OfType<DependencyTrackingTelemetryModule>().Single();
 
                 //VALIDATE
-                Assert.Equal(0, dependencyModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Count);
+                Assert.Equal(4, dependencyModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Count);
+                Assert.False(dependencyModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Contains("localhost"));
+                Assert.False(dependencyModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Contains("127.0.0.1"));
             }
 
             [Fact]
@@ -550,7 +552,9 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var dependencyModule = modules.OfType<DependencyTrackingTelemetryModule>().Single();
 
                 //VALIDATE
-                Assert.True(dependencyModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Count > 0);
+                Assert.Equal(6, dependencyModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Count);
+                Assert.True(dependencyModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Contains("localhost"));
+                Assert.True(dependencyModule.ExcludeComponentCorrelationHttpHeadersOnDomains.Contains("127.0.0.1"));
             }
 
             [Fact]

--- a/test/WebApi20.FunctionalTests/FunctionalTest/RequestTelemetryWebApiTests.cs
+++ b/test/WebApi20.FunctionalTests/FunctionalTest/RequestTelemetryWebApiTests.cs
@@ -279,6 +279,12 @@
                     return builder.ConfigureServices(services =>
                     {
                         services.AddApplicationInsightsTelemetry(o => o.RequestCollectionOptions.EnableW3CDistributedTracing = true);
+                        services.ConfigureTelemetryModule<DependencyTrackingTelemetryModule>((m, o) =>
+                        {
+                            // no correlation headers so we can test request
+                            // call without auto-injected w3c headers
+                            m.ExcludeComponentCorrelationHttpHeadersOnDomains.Add("localhost");
+                        });
                     });
                 }))
             {

--- a/test/WebApi20.FunctionalTests/FunctionalTest/RequestTelemetryWebApiTests.cs
+++ b/test/WebApi20.FunctionalTests/FunctionalTest/RequestTelemetryWebApiTests.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
     using System.Text.RegularExpressions;
 
     using FunctionalTestUtils;
@@ -106,8 +105,6 @@
                 return builder.ConfigureServices(services =>
                 {
                     services.AddApplicationInsightsTelemetry();
-                    services.Remove(services.Single(sd =>
-                        sd.ImplementationType == typeof(DependencyTrackingTelemetryModule)));
                 });
             }
 
@@ -201,9 +198,6 @@
                 return builder.ConfigureServices(services =>
                 {
                     services.AddApplicationInsightsTelemetry(o => o.RequestCollectionOptions.EnableW3CDistributedTracing = true);
-                    var depCollectorSd = services.Single(sd =>
-                        sd.ImplementationType == typeof(DependencyTrackingTelemetryModule));
-                    services.Remove(depCollectorSd);
                 });
             }))
             {


### PR DESCRIPTION
Fix Issue https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1120 on AspNetCore

We added localhost and 127.0.0.1 to the list of domains for which we don't inject correlation headers because of legacy (x-ms* headers). Injecting them into the request breaks Azure Storage SDK auth mechanism and causes errors on the emulator.

However, these headers are opt-in since AspNetCore SDK 2.4.0 (DepCollector 2.6.0) and we can safely add correlation headers on localhost.

This change removes localhost and 127.0.0.1 from the excluded list by default (if legacy headers are not on).
It also adds configuration to enable legacy headers and in this case excludes localhost and 127.0.0.1

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
