### PR TITLE
Fix TypeInitializationException for WebHostBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.6.0
+- [Fix: TypeInitializationException when Microsoft.AspNetCore.Hosting and Microsoft.AspNetCore.Hosting.Abstractions versions do not match](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/821)
+
 ## Version 2.6.0-beta3
 - Updated Web/Base SDK version dependency to 2.9.0-beta3
 - [Deprecate ApplicationInsightsLoggerFactoryExtensions.AddApplicationInsights logging extensions in favor of Microsoft.Extensions.Logging.ApplicationInsights package](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/817)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
+
 namespace Microsoft.ApplicationInsights.AspNetCore
 {
     using System;
@@ -59,12 +62,23 @@ namespace Microsoft.ApplicationInsights.AspNetCore
                     {
                         this.telemetryClient = new TelemetryClient(configuration);
 
+                        bool IsAspNetCore2 = true;
+                        try
+                        {
+                            IsAspNetCore2 = typeof(IWebHostBuilder).GetTypeInfo().Assembly.GetName().Version.Major >= 2;
+                        }
+                        catch (Exception)
+                        {
+                            // ignore any errors
+                        }
+
                         this.diagnosticListeners.Add(new HostingDiagnosticListener(
                             this.telemetryClient,
                             this.applicationIdProvider,
                             this.CollectionOptions.InjectResponseHeaders,
                             this.CollectionOptions.TrackExceptions,
-                            this.CollectionOptions.EnableW3CDistributedTracing));
+                            this.CollectionOptions.EnableW3CDistributedTracing,
+                            IsAspNetCore2));
 
                         this.diagnosticListeners.Add
                             (new MvcDiagnosticsListener());

--- a/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
@@ -1,16 +1,17 @@
-using System.Reflection;
-using Microsoft.AspNetCore.Hosting;
-
 namespace Microsoft.ApplicationInsights.AspNetCore
 {
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Reflection;
     using System.Threading;
+
     using Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.Extensibility;
+
+    using Microsoft.AspNetCore.Hosting;
 
     /// <summary>
     /// Telemetry module tracking requests using Diagnostic Listeners.
@@ -62,10 +63,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore
                     {
                         this.telemetryClient = new TelemetryClient(configuration);
 
-                        bool IsAspNetCore2 = true;
+                        bool enableNewDiagnosticEvents = true;
                         try
                         {
-                            IsAspNetCore2 = typeof(IWebHostBuilder).GetTypeInfo().Assembly.GetName().Version.Major >= 2;
+                            enableNewDiagnosticEvents = typeof(IWebHostBuilder).GetTypeInfo().Assembly.GetName().Version.Major >= 2;
                         }
                         catch (Exception)
                         {
@@ -78,7 +79,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore
                             this.CollectionOptions.InjectResponseHeaders,
                             this.CollectionOptions.TrackExceptions,
                             this.CollectionOptions.EnableW3CDistributedTracing,
-                            IsAspNetCore2));
+                            enableNewDiagnosticEvents));
 
                         this.diagnosticListeners.Add
                             (new MvcDiagnosticsListener());

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/ExceptionTrackingMiddlewareTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/ExceptionTrackingMiddlewareTest.cs
@@ -15,15 +15,16 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests
         [Fact]
         public void InvokeTracksExceptionThrownByNextMiddlewareAsHandledByPlatform()
         {
-            using (var middleware = new HostingDiagnosticListener(
+            using (var hostingListener = new HostingDiagnosticListener(
                 CommonMocks.MockTelemetryClient(telemetry => this.sentTelemetry = telemetry),
                 CommonMocks.GetMockApplicationIdProvider(),
                 injectResponseHeaders: true,
                 trackExceptions: true,
-                enableW3CHeaders: false))
+                enableW3CHeaders: false,
+                enableNewDiagnosticEvents: true))
             {
-                middleware.OnSubscribe();
-                middleware.OnHostingException(null, null);
+                hostingListener.OnSubscribe();
+                hostingListener.OnHostingException(null, null);
 
                 Assert.NotNull(sentTelemetry);
                 Assert.IsType<ExceptionTelemetry>(sentTelemetry);
@@ -34,15 +35,16 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests
         [Fact]
         public void SdkVersionIsPopulatedByMiddleware()
         {
-            using (var middleware = new HostingDiagnosticListener(
+            using (var hostingListener = new HostingDiagnosticListener(
                 CommonMocks.MockTelemetryClient(telemetry => this.sentTelemetry = telemetry),
                 CommonMocks.GetMockApplicationIdProvider(),
                 injectResponseHeaders: true,
                 trackExceptions: true,
-                enableW3CHeaders: false))
+                enableW3CHeaders: false,
+                enableNewDiagnosticEvents: true))
             {
-                middleware.OnSubscribe();
-                middleware.OnHostingException(null, null);
+                hostingListener.OnSubscribe();
+                hostingListener.OnHostingException(null, null);
 
                 Assert.NotEmpty(sentTelemetry.Context.GetInternalContext().SdkVersion);
                 Assert.Contains(SdkVersionTestUtils.VersionPrefix,


### PR DESCRIPTION
```
System.TypeInitializationException : The type initializer for 'Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners.HostingDiagnosticListener' threw an exception.
---- System.TypeLoadException : Method 'ConfigureAppConfiguration' in type 'Microsoft.AspNetCore.Hosting.WebHostBuilder' from assembly 'Microsoft.AspNetCore.Hosting, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' does not have an implementation.
   at Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners.HostingDiagnosticListener.Dispose()
   at Microsoft.ApplicationInsights.AspNetCore.RequestTrackingTelemetryModule.Dispose(Boolean disposing)
```

HostingDiagnosticListener uses WebHostBuilder class to determine Asp.NET Core version. Base IWebHostBuilder interface is loaded from Microsoft.AspNetCore.Hosting.Abstractions while WebHostBuilder is defined in Microsoft.AspNetCore.Hosting.
AppInsights SDK reference Ms.AspNetCore.Hosting 1.0.2. 

In AspNetCore 2.0 timeframe, a new interface method `ConfigureAppConfiguration` was added to IWebHostBuilder, which 1.0.2 does not implement.

If user app does reference abstractions of relevant version (2.0+), but not hosting, the base interface has `ConfigureAppConfiguration` while implementation AppInsights brings in 1.0.2 does not implement it which causes this error.

This is the case in WebJobs.

This change determines AspNetCore version based on IWebHodstBuilder to avoid issues like this.

It also changes how we test HostingDiagnosticListener, allowing to parametrize aspnetcore version and test different combinations.