### PR TITLE
Switch to W3C in base, and not in DependencyCollector

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -12,12 +12,11 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.W3C;
+    using Microsoft.ApplicationInsights.Extensibility.W3C;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.DiagnosticAdapter;
     using Microsoft.Extensions.Primitives;
 
-#pragma warning disable 612, 618
     /// <summary>
     /// <see cref="IApplicationInsightDiagnosticListener"/> implementation that listens for events specific to AspNetCore hosting layer.
     /// </summary>
@@ -482,7 +481,7 @@
         private void SetW3CContext(IHeaderDictionary requestHeaders, Activity activity, out string sourceAppId)
         {
             sourceAppId = null;
-            if (requestHeaders.TryGetValue(W3CConstants.TraceParentHeader, out StringValues traceParentValues))
+            if (requestHeaders.TryGetValue(W3C.W3CConstants.TraceParentHeader, out StringValues traceParentValues))
             {
                 var parentTraceParent = StringUtilities.EnforceMaxLength(traceParentValues.First(),
                     InjectionGuardConstants.TraceParentHeaderMaxLength);
@@ -493,7 +492,7 @@
                 activity.GenerateW3CContext();
             }
 
-            string[] traceStateValues = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(requestHeaders, W3CConstants.TraceStateHeader,
+            string[] traceStateValues = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(requestHeaders, W3C.W3CConstants.TraceStateHeader,
                 InjectionGuardConstants.TraceStateHeaderMaxLength, InjectionGuardConstants.TraceStateMaxPairs);
 
             if (traceStateValues != null && traceStateValues.Any())
@@ -501,7 +500,7 @@
                 var pairsExceptAz = new StringBuilder();
                 foreach (var t in traceStateValues)
                 {
-                    if (t.StartsWith(W3CConstants.AzureTracestateNamespace + "=", StringComparison.Ordinal))
+                    if (t.StartsWith(W3C.W3CConstants.AzureTracestateNamespace + "=", StringComparison.Ordinal))
                     {
                         // start after 'az='
                         TryExtractAppIdFromAzureTracestate(t.Substring(3), out sourceAppId);
@@ -543,9 +542,9 @@
         private static bool TryExtractAppIdFromAzureTracestate(string azTracestate, out string appId)
         {
             appId = null;
-            var parts = azTracestate.Split(W3CConstants.TracestateAzureSeparator);
+            var parts = azTracestate.Split(W3C.W3CConstants.TracestateAzureSeparator);
 
-            var appIds = parts.Where(p => p.StartsWith(W3CConstants.ApplicationIdTraceStateField, StringComparison.Ordinal)).ToArray();
+            var appIds = parts.Where(p => p.StartsWith(W3C.W3CConstants.ApplicationIdTraceStateField, StringComparison.Ordinal)).ToArray();
 
             if (appIds.Length != 1)
             {
@@ -561,5 +560,4 @@
             SubscriptionManager.Detach(this);
         }
     }
-#pragma warning restore 612, 618
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -9,11 +9,10 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
-    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
     using Microsoft.Extensions.Options;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-    using Microsoft.ApplicationInsights.W3C;
+    using Microsoft.ApplicationInsights.Extensibility.W3C;
 
     /// <summary>
     /// Initializes TelemetryConfiguration based on values in <see cref="ApplicationInsightsServiceOptions"/>
@@ -185,11 +184,9 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-#pragma warning disable 612, 618
         private void EnableW3CHeaders(TelemetryConfiguration configuration)
         {
             configuration.TelemetryInitializers.Add(new W3COperationCorrelationTelemetryInitializer());
         }
-#pragma warning restore 612, 618
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -81,7 +81,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.0-beta3" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.0-beta3-build22323" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.9.0-beta3" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.9.0-beta3" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.9.0-beta3" />

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -1003,7 +1003,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.False(heartbeatModule.IsHeartbeatEnabled);
             }
 
-#pragma warning disable 612, 618
             [Fact]
             public static void W3CIsDisabledByDefault()
             {
@@ -1046,7 +1045,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 Assert.True(requestTracking.Single().CollectionOptions.EnableW3CDistributedTracing);
                 Assert.True(dependencyTracking.Single().EnableW3CHeadersInjection);
             }
-#pragma warning restore 612, 618
 
             private static int GetTelemetryProcessorsCountInConfiguration<T>(TelemetryConfiguration telemetryConfiguration)
             {

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
-    using Microsoft.ApplicationInsights.W3C;
+    using Microsoft.ApplicationInsights.Extensibility.W3C;
     using Microsoft.ApplicationInsights.WindowsServer;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
     using Microsoft.AspNetCore.Hosting;

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
@@ -14,7 +14,7 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.W3C;
+    using Microsoft.ApplicationInsights.Extensibility.W3C;
     using Microsoft.AspNetCore.Http;
     using Xunit;
 
@@ -660,7 +660,6 @@
             Assert.True(string.IsNullOrEmpty(requestTelemetry.Source));
         }
 
-#pragma warning disable 612, 618
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -901,7 +900,6 @@
                 Assert.Equal($"appId={CommonMocks.TestApplicationId}", appId);
             }
         }
-#pragma warning restore 612, 618
 
         private void HandleRequestBegin(HostingDiagnosticListener hostingListener, HttpContext context, long timestamp, bool isAspNetCore2)
         {

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
@@ -737,7 +737,11 @@
 
                 var activityInitializedByW3CHeader = Activity.Current;
 
-                Assert.Equal("|abc.1.2.3.", activityInitializedByW3CHeader.ParentId);
+                if (isAspNetCore2)
+                {
+                    Assert.Equal("|abc.1.2.3.", activityInitializedByW3CHeader.ParentId);
+                }
+
                 Assert.Equal("4bf92f3577b34da6a3ce929d0e0e4736", activityInitializedByW3CHeader.GetTraceId());
                 Assert.Equal("00f067aa0ba902b7", activityInitializedByW3CHeader.GetParentSpanId());
                 Assert.Equal(16, activityInitializedByW3CHeader.GetSpanId().Length);
@@ -759,8 +763,11 @@
                     out var appId));
                 Assert.Equal($"appId={CommonMocks.TestApplicationId}", appId);
 
-                Assert.Equal("abc", requestTelemetry.Properties["ai_legacyRootId"]);
-                Assert.StartsWith("|abc.1.2.3.", requestTelemetry.Properties["ai_legacyRequestId"]);
+                if (isAspNetCore2)
+                {
+                    Assert.Equal("abc", requestTelemetry.Properties["ai_legacyRootId"]);
+                    Assert.StartsWith("|abc.1.2.3.", requestTelemetry.Properties["ai_legacyRequestId"]);
+                }
             }
         }
 

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
@@ -678,9 +678,9 @@
                 hostingListener.OnSubscribe();
                 var context = CreateContext(HttpRequestScheme, HttpRequestHost, "/Test", method: "POST");
 
-                context.Request.Headers[W3CConstants.TraceParentHeader] =
+                context.Request.Headers[W3C.W3CConstants.TraceParentHeader] =
                     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
-                context.Request.Headers[W3CConstants.TraceStateHeader] = "state=some";
+                context.Request.Headers[W3C.W3CConstants.TraceStateHeader] = "state=some";
                 context.Request.Headers[RequestResponseHeaders.CorrelationContextHeader] = "k=v";
 
                 HandleRequestBegin(hostingListener, context, 0, isAspNetCore2);
@@ -728,9 +728,9 @@
                 var context = CreateContext(HttpRequestScheme, HttpRequestHost, "/Test", method: "POST");
 
                 context.Request.Headers[RequestResponseHeaders.RequestIdHeader] = "|abc.1.2.3.";
-                context.Request.Headers[W3CConstants.TraceParentHeader] =
+                context.Request.Headers[W3C.W3CConstants.TraceParentHeader] =
                     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
-                context.Request.Headers[W3CConstants.TraceStateHeader] = "state=some";
+                context.Request.Headers[W3C.W3CConstants.TraceStateHeader] = "state=some";
                 context.Request.Headers[RequestResponseHeaders.CorrelationContextHeader] = "k=v";
 
                 HandleRequestBegin(hostingListener, context, 0, isAspNetCore2);
@@ -878,10 +878,10 @@
 
                 var context = CreateContext(HttpRequestScheme, HttpRequestHost, "/Test", method: "POST");
 
-                context.Request.Headers[W3CConstants.TraceParentHeader] =
+                context.Request.Headers[W3C.W3CConstants.TraceParentHeader] =
                     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00";
-                context.Request.Headers[W3CConstants.TraceStateHeader] =
-                    $"state=some,{W3CConstants.AzureTracestateNamespace}={ExpectedAppId}";
+                context.Request.Headers[W3C.W3CConstants.TraceStateHeader] =
+                    $"state=some,{W3C.W3CConstants.AzureTracestateNamespace}={ExpectedAppId}";
 
                 HandleRequestBegin(hostingListener, context, 0, isAspNetCore2);
                 var activityInitializedByW3CHeader = Activity.Current;

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HttpHeadersUtilitiesTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HttpHeadersUtilitiesTest.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Linq;
     using DiagnosticListeners;
-    using Microsoft.ApplicationInsights.W3C;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Primitives;
     using Xunit;
@@ -45,10 +44,11 @@
         public void GetRequestContextKeyValueShouldReturnContextKeyValue()
         {
             IHeaderDictionary headerDictionary = new HeaderDictionary(
-    new Dictionary<string, StringValues>() {
-                                { RequestResponseHeaders.RequestContextHeader, new StringValues("app=id") },
-                                { "NoizyName", new StringValues("noizy=noizy-id") }
-});
+                new Dictionary<string, StringValues>()
+                {
+                    {RequestResponseHeaders.RequestContextHeader, new StringValues("app=id")},
+                    {"NoizyName", new StringValues("noizy=noizy-id")}
+                });
 
             string actual = HttpHeadersUtilities.GetRequestContextKeyValue(headerDictionary, "app");
 
@@ -127,12 +127,11 @@
             Assert.False(HttpHeadersUtilities.ContainsRequestContextKeyValue(headers, "Non-exists"));
         }
 
-#pragma warning disable 612, 618
         [Fact]
         public void GetHeaderValueEmpty()
         {
             IHeaderDictionary headers = new HeaderDictionary();
-            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3CConstants.TraceStateHeader, 100500, 100500)?.ToList();
+            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3C.W3CConstants.TraceStateHeader, 100500, 100500)?.ToList();
             Assert.NotNull(values);
             Assert.Empty(values);
         }
@@ -140,8 +139,8 @@
         [Fact]
         public void GetHeaderValueNoMax1()
         {
-            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3CConstants.TraceStateHeader] = "k1=v1,k2=v2" });
-            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3CConstants.TraceStateHeader, 100500, 100500)?.ToList();
+            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3C.W3CConstants.TraceStateHeader] = "k1=v1,k2=v2" });
+            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3C.W3CConstants.TraceStateHeader, 100500, 100500)?.ToList();
             Assert.NotNull(values);
             Assert.Equal(2, values.Count);
             Assert.Equal("k1=v1", values.First());
@@ -151,8 +150,8 @@
         [Fact]
         public void GetHeaderValueNoMax2()
         {
-            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3CConstants.TraceStateHeader] = new []{"k1=v1,k2=v2", "k3=v3,k4=v4" }});
-            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3CConstants.TraceStateHeader, 100500, 100500)?.ToList();
+            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3C.W3CConstants.TraceStateHeader] = new []{"k1=v1,k2=v2", "k3=v3,k4=v4" }});
+            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3C.W3CConstants.TraceStateHeader, 100500, 100500)?.ToList();
             Assert.NotNull(values);
             Assert.Equal(4, values.Count);
             Assert.Equal("k1=v1", values[0]);
@@ -168,8 +167,8 @@
         [InlineData(13)] // k1=v1,k2=v2,k".Length
         public void GetHeaderValueMaxLenTruncatesEnd(int maxLength)
         {
-            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3CConstants.TraceStateHeader] = "k1=v1,k2=v2,k3=v3,k4=v4" });
-            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3CConstants.TraceStateHeader, maxLength, 100500)?.ToList();
+            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3C.W3CConstants.TraceStateHeader] = "k1=v1,k2=v2,k3=v3,k4=v4" });
+            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3C.W3CConstants.TraceStateHeader, maxLength, 100500)?.ToList();
             Assert.NotNull(values);
             Assert.Equal(2, values.Count);
             Assert.Equal("k1=v1", values.First());
@@ -183,8 +182,8 @@
         [InlineData(13)] // k1=v1,k2=v2,k".Length
         public void GetHeaderValueMaxLenTruncatesEnd2(int maxLength)
         {
-            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3CConstants.TraceStateHeader] = new[] { "k1=v1,k2=v2", "k3=v3,k4=v4" } });
-            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3CConstants.TraceStateHeader, maxLength, 100500)?.ToList();
+            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3C.W3CConstants.TraceStateHeader] = new[] { "k1=v1,k2=v2", "k3=v3,k4=v4" } });
+            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3C.W3CConstants.TraceStateHeader, maxLength, 100500)?.ToList();
             Assert.NotNull(values);
             Assert.Equal(2, values.Count);
             Assert.Equal("k1=v1", values.First());
@@ -196,8 +195,8 @@
         [InlineData(3)]
         public void GetHeaderValueMaxLenTruncatesEndInvalid(int maxLength)
         {
-            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3CConstants.TraceStateHeader] = "k1=v1,k2=v2" });
-            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3CConstants.TraceStateHeader, maxLength, 100500)?.ToList();
+            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3C.W3CConstants.TraceStateHeader] = "k1=v1,k2=v2" });
+            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3C.W3CConstants.TraceStateHeader, maxLength, 100500)?.ToList();
             Assert.NotNull(values);
             Assert.Empty(values);
         }
@@ -205,8 +204,8 @@
         [Fact]
         public void GetHeaderValueMaxItemsTruncatesEndInvalid()
         {
-            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3CConstants.TraceStateHeader] = "k1=v1,k2=v2" });
-            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3CConstants.TraceStateHeader, 100500, 0)?.ToList();
+            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3C.W3CConstants.TraceStateHeader] = "k1=v1,k2=v2" });
+            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3C.W3CConstants.TraceStateHeader, 100500, 0)?.ToList();
             Assert.NotNull(values);
             Assert.Empty(values);
         }
@@ -214,14 +213,12 @@
         [Fact]
         public void GetHeaderValueMaxItemsTruncatesEnd()
         {
-            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3CConstants.TraceStateHeader] = "k1=v1,k2=v2,k3=v3,k4=v4" });
-            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3CConstants.TraceStateHeader, 100500, 2)?.ToList();
+            IHeaderDictionary headers = new HeaderDictionary(new Dictionary<string, StringValues> { [W3C.W3CConstants.TraceStateHeader] = "k1=v1,k2=v2,k3=v3,k4=v4" });
+            var values = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(headers, W3C.W3CConstants.TraceStateHeader, 100500, 2)?.ToList();
             Assert.NotNull(values);
             Assert.Equal(2, values.Count);
             Assert.Equal("k1=v1", values.First());
             Assert.Equal("k2=v2", values.Last());
         }
-#pragma warning restore 612, 618
-
     }
 }

--- a/test/WebApi20.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
+++ b/test/WebApi20.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
@@ -7,12 +7,11 @@
     using Microsoft.ApplicationInsights.AspNetCore;
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.W3C;
+    using Microsoft.ApplicationInsights.Extensibility.W3C;
     using Microsoft.Extensions.DependencyInjection;
     using Xunit;
     using Xunit.Abstractions;
 
-#pragma warning disable 612, 618
     public class TelemetryModuleWorkingWebApiTests : TelemetryTestsBase, IDisposable
     {
         private const string assemblyName = "WebApi20.FunctionalTests20";
@@ -101,5 +100,4 @@
             }
         }
     }
-#pragma warning restore 612, 618
 }


### PR DESCRIPTION
W3C implementation is used by Web and AspNetCore SDKs.

We are going to enable W3C for some 1DS users that do not necessarily use Web SDK (and reference DependencyCollector that declares W3C implementation).

Without this change, we would require everyone to install base + dependency collector just to onboard W3C. With this change, it is still an explicit choice to enable it.

W3C is moved to base, Implementation in dependency collector is deprecated.