### PR TITLE
Prepare for 2.6.0 release and LicenseUrl update

### DIFF
--- a/.vsts/linux-build.yml
+++ b/.vsts/linux-build.yml
@@ -47,6 +47,11 @@ steps:
     testRunner: "VSTest"
     testResultsFiles: "**/*.trx"
 
+- task: DotNetCoreInstaller@0
+  displayName: install dotnet core 2.1.500
+  inputs:
+    version: "2.1.500"
+
 - task: DotNetCoreCLI@1
   displayName: Package Nuget
   inputs:

--- a/.vsts/linux-build.yml
+++ b/.vsts/linux-build.yml
@@ -3,9 +3,9 @@ queue:
 steps:  
 
 - task: DotNetCoreInstaller@0
-  displayName: install dotnet core 2.0
+  displayName: install dotnet core 2.1.500
   inputs:
-    version: "2.0.0"
+    version: "2.1.500"
     
 - task: DotNetCoreCLI@1
   displayName: Restore solutions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version 2.6.0
+- Updated Web/Base SDK version dependency to 2.9.0
 - [Fix: TypeInitializationException when Microsoft.AspNetCore.Hosting and Microsoft.AspNetCore.Hosting.Abstractions versions do not match](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/821)
 
 ## Version 2.6.0-beta3

--- a/NugetAudit.ps1
+++ b/NugetAudit.ps1
@@ -15,7 +15,7 @@ Param(
 
 $requiredCopyright = "$([char]0x00A9) Microsoft Corporation. All rights reserved.";#"© Microsoft Corporation. All rights reserved.";
 $expectedProjectUrl = "https://go.microsoft.com/fwlink/?LinkId=392727"; # Application Insights Project Url
-$expectedLicenseUrl = "https://go.microsoft.com/fwlink/?LinkID=510709"; # Application Insights license Url
+$expectedLicense = "MIT"; # MIT License SPDX ID
 $expectedOwner = "AppInsightsSdk"; # Application Insights Nuget Account
 $expectedTags = @("Azure","Monitoring");
 
@@ -175,14 +175,13 @@ function Get-IsValidProjectUrl([xml]$nuspecXml) {
     Test-Condition ($projectUrl -eq $expectedProjectUrl) $message $requirement;
 }
 
-function Get-IsValidLicenseUrl([xml]$nuspecXml) {
-    $licenseUrl = $nuspecXml.package.metadata.licenseUrl;
+function Get-IsValidLicense([xml]$nuspecXml) {
+    $license = $nuspecXml.package.metadata.license;
 
-    $message = "License Url: $licenseUrl";
+    $message = "License Url: $license";
     $requirement = "Must match expected."
-    $recommendation = "Should not use FWLINK."
 
-    Test-MultiCondition ($licenseUrl -eq $expectedLicenseUrl) ($licenseUrl -notlike "*fwlink*") $message $requirement $recommendation;
+    Test-Condition ($license -eq $expectedLicense) $message $requirement;
 }
 
 function Get-IsValidLicenseAcceptance([xml]$nuspecXml) {
@@ -291,7 +290,7 @@ function Start-EvaluateNupkg ($nupkgPath) {
         Get-IsValidAuthors $nuspecXml;
         Get-IsValidOwners $nuspecXml;
         Get-IsValidProjectUrl $nuspecXml;
-        Get-IsValidLicenseUrl $nuspecXml;
+        Get-IsValidLicense $nuspecXml;
         Get-IsValidLicenseAcceptance $nuspecXml;
         Get-IsValidCopyright $nuspecXml;
         Get-IsValidLogoUrl $nuspecXml $unzipPath;

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore</AssemblyName>
-    <VersionPrefix>2.6.0-beta3</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Application Insights for ASP.NET Core Web Applications</AssemblyTitle>
@@ -25,7 +25,7 @@
     <PackageId>Microsoft.ApplicationInsights.AspNetCore</PackageId>
     <PackageTags>Azure;Monitoring;Analytics;ApplicationInsights;Telemetry;AppInsights;aspnetcore;</PackageTags>
     <PackageIconUrl>https://appanacdn.blob.core.windows.net/cdn/icons/aic.png</PackageIconUrl>
-    <PackageLicenseUrl>https://go.microsoft.com/fwlink/?LinkID=510709</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?LinkId=392727</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
@@ -81,11 +81,11 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.0-beta3-build22323" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.9.0-beta3" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.9.0-beta3" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.9.0-beta3" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.9.0-beta3" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.9.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.9.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.9.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />


### PR DESCRIPTION
- Update version to 2.6.0
- Update base / web / other dependencies to 2.9.0
- LicenseUrl fix
