### PR TITLE
Avoid duplicate exception from Request module and ILogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.7.0-beta4
+- [RequestTrackingTelemetryModule is modified to stop tracking exceptions by default, as exceptions are captured by ApplicationInsightsLoggerProvider.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/861)
+
 ## Version 2.7.0-beta3
 - [Enables Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider by default. If ApplicationInsightsLoggerProvider was enabled previously using ILoggerFactory extension method, please remove it to prevent duplicate logs.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/854)
 - [Remove reference to Microsoft.Extensions.DiagnosticAdapter and use DiagnosticSource subscription APIs directly](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/852) 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/RequestCollectionOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/RequestCollectionOptions.cs
@@ -11,7 +11,13 @@
         public RequestCollectionOptions()
         {
             this.InjectResponseHeaders = true;
+            // In NetStandard20, ApplicationInsightsLoggerProvider is enabled by default,
+            // which captures Exceptions. Disabling it in RequestCollectionModule to avoid duplication.
+#if NETSTANDARD2_0
             this.TrackExceptions = false;
+#else
+            this.TrackExceptions = true;
+#endif
             this.EnableW3CDistributedTracing = false;
         }
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/RequestCollectionOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/RequestCollectionOptions.cs
@@ -11,7 +11,7 @@
         public RequestCollectionOptions()
         {
             this.InjectResponseHeaders = true;
-            this.TrackExceptions = true;
+            this.TrackExceptions = false;
             this.EnableW3CDistributedTracing = false;
         }
 

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -701,7 +701,11 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                                                                                                                 == typeof(RequestTrackingTelemetryModule));
 
                 Assert.True(requestTrackingModule.CollectionOptions.InjectResponseHeaders);
+#if NETCOREAPP2_0
+                Assert.False(requestTrackingModule.CollectionOptions.TrackExceptions);
+#else
                 Assert.True(requestTrackingModule.CollectionOptions.TrackExceptions);
+#endif
             }
 
             [Fact]


### PR DESCRIPTION
Fix Issue #861  .
Fixed by setting default value for `TrackExceptions` in `RequestCollectionOptions` to be false. User who disable ILogger (using filters), can get the exceptions from RequestTrackingModule, by modifying `TrackExceptions` in `RequestCollectionOptions`  to true, as shown below:

```csharp
public void ConfigureServices(IServiceCollection services)
        {            
            services.AddApplicationInsightsTelemetry();
services.ConfigureTelemetryModule<Microsoft.ApplicationInsights.AspNetCore.RequestTrackingTelemetryModule>((req, o) => req.CollectionOptions.TrackExceptions = true);
        }
```

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
