### PR TITLE
Performance fixes, wave 1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Version 2.7.0-beta1
 - Added NetStandard2.0 target.
 
+## Version 2.6.1
+- Updated Web/Base SDK version dependency to 2.9.1
+
 ## Version 2.6.0
 - Updated Web/Base SDK version dependency to 2.9.0
 - [Fix: TypeInitializationException when Microsoft.AspNetCore.Hosting and Microsoft.AspNetCore.Hosting.Abstractions versions do not match](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/821)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [Enables Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider by default. If ApplicationInsightsLoggerProvider was enabled previously using ILoggerFactory extension method, please remove it to prevent duplicate logs.](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/854)
 - [Remove reference to Microsoft.Extensions.DiagnosticAdapter and use DiagnosticSource subscription APIs directly](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/852) 
 - [Fix: NullReferenceException in ApplicationInsightsLogger.Log when exception contains a Data entry with a null value](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/848)
+- [Performance fixes for GetUri, SetKeyHeaderValue, ConcurrentDictionary use and Telemetry Initializers](https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/864)
 
 ## Version 2.7.0-beta2
 - Added NetStandard2.0 target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.7.0-beta3
+- [Fix: NullReferenceException in ApplicationInsightsLogger.Log when exception contains a Data entry with a null value](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/848)
+
 ## Version 2.7.0-beta2
 - Added NetStandard2.0 target.
 - Updated Web/Base SDK version dependency to 2.10.0-beta2

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HeadersUtilities.cs
@@ -5,6 +5,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
     using System.Linq;
     using System.Text.RegularExpressions;
     using Microsoft.ApplicationInsights.Common;
+    using Microsoft.Extensions.Primitives;
 
     /// <summary>
     /// Generic functions that can be used to get and set Http headers.
@@ -20,7 +21,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
         public static string GetHeaderKeyValue(IEnumerable<string> headerValues, string keyName)
         {
             if (headerValues != null)
-            {
+            {                
                 foreach (string keyNameValue in headerValues)
                 {
                     string[] keyNameValueParts = keyNameValue.Trim().Split('=');
@@ -54,6 +55,27 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
                 : headerValues
                     .Where(headerValue => !HeaderMatchesKey(headerValue, keyName))
                     .Concat(newHeaderKeyValue);
+        }
+
+        internal static StringValues SetHeaderKeyValue(string[] currentHeaders, string key, string value)
+        {
+            if (currentHeaders != null)
+            {
+                for (int index = 0; index < currentHeaders.Length; index++)
+                {
+                    if (HeaderMatchesKey(currentHeaders[index], key))
+                    {
+                        currentHeaders[index] = string.Concat(key, "=", value);
+                        return currentHeaders;
+                    }
+                }
+
+                return StringValues.Concat(currentHeaders, string.Concat(key, "=", value));                
+            }
+            else
+            {
+                return string.Concat(key, "=", value);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HeadersUtilities.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
         /// <param name="keyName">The name of the key to add.</param>
         /// <param name="keyValue">The value of the key to add.</param>
         /// <returns>The result of setting the provided key name/value pair into the provided headerValues.</returns>
-        internal static StringValues SetHeaderKeyValue(string[] currentHeaders, string key, string value)
+        public static StringValues SetHeaderKeyValue(string[] currentHeaders, string key, string value)
         {
             if (currentHeaders != null)
             {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HeadersUtilities.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
         /// <summary>
         /// Given the provided list of header value strings, return a comma-separated list of key
         /// name/value pairs with the provided keyName and keyValue. If the initial header value
-        /// strings contains the key name, then the original key value should be replaced with the
+        /// string contains the key name, then the original key value should be replaced with the
         /// provided key value. If the initial header value strings don't contain the key name,
         /// then the key name/value pair should be added to the comma-separated list and returned.
         /// </summary>
@@ -47,16 +47,6 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
         /// <param name="keyName">The name of the key to add.</param>
         /// <param name="keyValue">The value of the key to add.</param>
         /// <returns>The result of setting the provided key name/value pair into the provided headerValues.</returns>
-        public static IEnumerable<string> SetHeaderKeyValue(IEnumerable<string> headerValues, string keyName, string keyValue)
-        {
-            string[] newHeaderKeyValue = new[] { string.Format(CultureInfo.InvariantCulture, "{0}={1}", keyName.Trim(), keyValue.Trim()) };
-            return headerValues == null || !headerValues.Any()
-                ? newHeaderKeyValue
-                : headerValues
-                    .Where(headerValue => !HeaderMatchesKey(headerValue, keyName))
-                    .Concat(newHeaderKeyValue);
-        }
-
         internal static StringValues SetHeaderKeyValue(string[] currentHeaders, string key, string value)
         {
             if (currentHeaders != null)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -366,7 +366,7 @@
             {
                 headerCorrelationId = StringUtilities.EnforceMaxLength(headerCorrelationId, InjectionGuardConstants.AppIdMaxLength);
                 if (string.IsNullOrEmpty(instrumentationKey))
-                {In
+                {
                     return headerCorrelationId;
                 }
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -161,7 +161,15 @@
                     // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
 
                     newActivity = new Activity(ActivityCreatedByHostingDiagnosticListener);
-                    newActivity.SetParentId(StringUtilities.GenerateTraceId());
+                    if (this.enableW3CHeaders)
+                    {
+                        newActivity.GenerateW3CContext();
+                        newActivity.SetParentId(newActivity.GetTraceId());
+                    }
+                    else
+                    {
+                        newActivity.SetParentId(W3CUtilities.GenerateTraceId());
+                    }
                     // end of workaround
                 }
 
@@ -257,7 +265,9 @@
                             InjectionGuardConstants.RequestHeaderMaxLength);
                     }
                 }
-                else if(!activity.IsW3CActivity())
+
+                // no headers
+                else if (originalParentId == null)
                 {
                     // As a first step in supporting W3C protocol in ApplicationInsights,
                     // we want to generate Activity Ids in the W3C compatible format.
@@ -266,8 +276,16 @@
                     // So if there is no current Activity (i.e. there were no Request-Id header in the incoming request), we'll override ParentId on 
                     // the current Activity by the properly formatted one. This workaround should go away
                     // with W3C support on .NET https://github.com/dotnet/corefx/issues/30331
-                    
-                    activity.SetParentId(StringUtilities.GenerateTraceId());
+
+                    if (this.enableW3CHeaders)
+                    {
+                        activity.GenerateW3CContext();
+                        activity.SetParentId(activity.GetTraceId());
+                    }
+                    else
+                    {
+                        activity.SetParentId(W3CUtilities.GenerateTraceId());
+                    }
 
                     // end of workaround
                 }
@@ -336,6 +354,10 @@
             {
                 requestTelemetry.Context.Operation.Id = activity.RootId;
                 requestTelemetry.Id = activity.Id;
+            }
+            else
+            {
+                activity.UpdateTelemetry(requestTelemetry, false);
             }
 
             foreach (var prop in activity.Baggage)
@@ -489,10 +511,6 @@
                 var parentTraceParent = StringUtilities.EnforceMaxLength(traceParentValues.First(),
                     InjectionGuardConstants.TraceParentHeaderMaxLength);
                 activity.SetTraceparent(parentTraceParent);
-            }
-            else
-            {
-                activity.GenerateW3CContext();
             }
 
             string[] traceStateValues = HttpHeadersUtilities.SafeGetCommaSeparatedHeaderValues(requestHeaders, W3C.W3CConstants.TraceStateHeader,

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -343,7 +343,7 @@
                 }
             }
 
-            this.client.Initialize(requestTelemetry);
+            this.client.InitializeInstrumentationKey(requestTelemetry);
 
             requestTelemetry.Source = GetAppIdFromRequestHeader(httpContext.Request.Headers, requestTelemetry.Context.InstrumentationKey);
 
@@ -363,7 +363,7 @@
             {
                 headerCorrelationId = StringUtilities.EnforceMaxLength(headerCorrelationId, InjectionGuardConstants.AppIdMaxLength);
                 if (string.IsNullOrEmpty(instrumentationKey))
-                {
+                {In
                     return headerCorrelationId;
                 }
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
                 throw new ArgumentNullException(nameof(headers));
             }
 
-            headers[headerName] = new StringValues(HeadersUtilities.SetHeaderKeyValue(headers[headerName].AsEnumerable(), keyName, keyValue).ToArray());
+            headers[headerName] = HeadersUtilities.SetHeaderKeyValue(headers[headerName], keyName, keyValue);
         }
 
         internal static string[] SafeGetCommaSeparatedHeaderValues(IHeaderDictionary headers, string headerName, int maxLength, int maxItems)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
@@ -65,26 +65,9 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
             return !string.IsNullOrEmpty(GetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName));
         }
 
-        internal static void SetRequestContextKeyValue(HttpHeaders headers, string keyName, string keyValue)
-        {
-            SetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName, keyValue);
-        }
-
         internal static void SetRequestContextKeyValue(IHeaderDictionary headers, string keyName, string keyValue)
         {
             SetHeaderKeyValue(headers, RequestResponseHeaders.RequestContextHeader, keyName, keyValue);
-        }
-
-        internal static void SetHeaderKeyValue(HttpHeaders headers, string headerName, string keyName, string keyValue)
-        {
-            if (headers == null)
-            {
-                throw new ArgumentNullException(nameof(headers));
-            }
-
-            IEnumerable<string> headerValues = GetHeaderValues(headers, headerName);
-            headers.Remove(headerName);
-            headers.Add(headerName, HeadersUtilities.SetHeaderKeyValue(headerValues, keyName, keyValue));
         }
 
         internal static void SetHeaderKeyValue(IHeaderDictionary headers, string headerName, string keyName, string keyValue)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/HttpRequestExtensions.cs
@@ -28,26 +28,12 @@
             {
                 throw new ArgumentException("Http request Scheme is not specified");
             }
-
-            string hostName = request.Host.HasValue ? request.Host.ToString() : UnknownHostName;
             
-            var builder = new StringBuilder();
-
-            builder.Append(request.Scheme)
-                .Append("://")
-                .Append(hostName);
-
-            if (true == request.Path.HasValue)
-            {
-                builder.Append(request.Path.Value);
-            }
-
-            if (true == request.QueryString.HasValue)
-            {
-                builder.Append(request.QueryString);
-            }
-
-            return new Uri(builder.ToString());
+            return new Uri(string.Concat(request.Scheme,
+                    "://",
+                    request.Host.HasValue ? request.Host.Value : UnknownHostName,
+                    request.Path.HasValue ? request.Path.Value : "",
+                    request.QueryString.HasValue ? request.QueryString.Value : ""));
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLogger.cs
@@ -69,7 +69,7 @@
                     exceptionTelemetry.Message = formatter(state, exception);
                     exceptionTelemetry.SeverityLevel = this.GetSeverityLevel(logLevel);
                     exceptionTelemetry.Properties["Exception"] = exception.ToString();
-                    exception.Data.Cast<DictionaryEntry>().ToList().ForEach((item) => exceptionTelemetry.Properties[item.Key.ToString()] = item.Value.ToString());
+                    exception.Data.Cast<DictionaryEntry>().ToList().ForEach((item) => exceptionTelemetry.Properties[item.Key.ToString()] = (item.Value ?? "null").ToString());
                     PopulateTelemetry(exceptionTelemetry, stateDictionary, eventId);
                     this.telemetryClient.TrackException(exceptionTelemetry);
                 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializer.cs
@@ -23,10 +23,10 @@
 
         /// <inheritdoc />
         public void Initialize(ITelemetry telemetry)
-        {
-            if (environment != null && !telemetry.Context.GlobalProperties.ContainsKey(AspNetCoreEnvironmentPropertyName))
+        {   
+            if (environment != null && !telemetry.Context.Properties.ContainsKey(AspNetCoreEnvironmentPropertyName))
             {
-                telemetry.Context.GlobalProperties.Add(AspNetCoreEnvironmentPropertyName, environment.EnvironmentName);
+                telemetry.Context.Properties.Add(AspNetCoreEnvironmentPropertyName, environment.EnvironmentName);
             }
         }
     }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HeadersUtilitiesTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HeadersUtilitiesTest.cs
@@ -45,7 +45,7 @@
             Assert.NotNull(result);
             Assert.Equal(2, result.Length);
             Assert.Equal("ExistKey=ExistValue", result[0]);
-            Assert.Equal("NewKey=NewValue", result[0]);
+            Assert.Equal("NewKey=NewValue", result[1]);
         }
 
         [Fact]
@@ -57,7 +57,7 @@
             Assert.NotNull(result);
             Assert.Equal(2, result.Length);
             Assert.Equal("ExistKey=NewValue", result[0]);
-            Assert.Equal("NoiseKey=NoiseValue", result[0]);
+            Assert.Equal("NoiseKey=NoiseValue", result[1]);
         }
     }
 }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HeadersUtilitiesTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HeadersUtilitiesTest.cs
@@ -1,7 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests
 {
     using System.Collections.Generic;
-    using System.Linq;
     using DiagnosticListeners;
     using Xunit;
 
@@ -30,36 +29,35 @@
         [Fact]
         public void ShouldReturnHeadersWhenNoHeaderValues()
         {
-            IEnumerable<string> newHeaders = HeadersUtilities.SetHeaderKeyValue(null, "Key", "Value");
+            string[] newHeaders = HeadersUtilities.SetHeaderKeyValue(null, "Key", "Value");
 
             Assert.NotNull(newHeaders);
-            Assert.Equal(1, newHeaders.Count());
-            Assert.Equal("Key=Value", newHeaders.First());
+            Assert.Single(newHeaders);
+            Assert.Equal("Key=Value", newHeaders[0]);
         }
 
         [Fact]
         public void ShouldAppendHeaders()
         {
-            IEnumerable<string> existing = new List<string>() { "ExistKey=ExistValue" };
-            IEnumerable<string> result = HeadersUtilities.SetHeaderKeyValue(existing, "NewKey", "NewValue");
+            string[] existing = new string[] { "ExistKey=ExistValue" };
+            string[] result = HeadersUtilities.SetHeaderKeyValue(existing, "NewKey", "NewValue");
 
             Assert.NotNull(result);
-            Assert.Equal(2, result.Count());
-            Assert.NotNull(result.FirstOrDefault(headerValue => headerValue.Equals("ExistKey=ExistValue")));
-            Assert.NotNull(result.FirstOrDefault(headerValue => headerValue.Equals("NewKey=NewValue")));
+            Assert.Equal(2, result.Length);
+            Assert.Equal("ExistKey=ExistValue", result[0]);
+            Assert.Equal("NewKey=NewValue", result[0]);
         }
 
         [Fact]
         public void ShouldUpdateExistingHeader()
         {
-            IEnumerable<string> existing = new List<string>() { "ExistKey=ExistValue", "NoiseKey=NoiseValue" };
-            IEnumerable<string> result = HeadersUtilities.SetHeaderKeyValue(existing, "ExistKey", "NewValue");
+            string[] existing = new string[] { "ExistKey=ExistValue", "NoiseKey=NoiseValue" };
+            string[] result = HeadersUtilities.SetHeaderKeyValue(existing, "ExistKey", "NewValue");
 
             Assert.NotNull(result);
-            Assert.Equal(2, result.Count());
-            Assert.Null(result.FirstOrDefault(headerValue => headerValue.Equals("ExistKey=ExistValue")));
-            Assert.NotNull(result.FirstOrDefault(headerValue => headerValue.Equals("ExistKey=NewValue")));
-            Assert.NotNull(result.FirstOrDefault(headerValue => headerValue.Equals("NoiseKey=NoiseValue")));
+            Assert.Equal(2, result.Length);
+            Assert.Equal("ExistKey=NewValue", result[0]);
+            Assert.Equal("NoiseKey=NoiseValue", result[0]);
         }
     }
 }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
@@ -836,10 +836,6 @@
 
                 var activityInitializedByW3CHeader = Activity.Current;
 
-                if (!isAspNetCore2)
-                { 
-                Assert.Null(activityInitializedByW3CHeader.ParentId);
-                    }
                 Assert.NotNull(activityInitializedByW3CHeader.GetTraceId());
                 Assert.Equal(32, activityInitializedByW3CHeader.GetTraceId().Length);
                 Assert.Equal(16, activityInitializedByW3CHeader.GetSpanId().Length);

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializerTests.cs
@@ -19,10 +19,10 @@
         {
             var initializer = new AspNetCoreEnvironmentTelemetryInitializer(new HostingEnvironment() { EnvironmentName = "Production"});
             var telemetry = new RequestTelemetry();
-            telemetry.Context.GlobalProperties.Add("AspNetCoreEnvironment", "Development");
+            telemetry.Context.Properties.Add("AspNetCoreEnvironment", "Development");
             initializer.Initialize(telemetry);
 
-            Assert.Equal("Development", telemetry.Context.GlobalProperties["AspNetCoreEnvironment"]);
+            Assert.Equal("Development", telemetry.Context.Properties["AspNetCoreEnvironment"]);
         }
 
         [Fact]
@@ -32,7 +32,7 @@
             var telemetry = new RequestTelemetry();
             initializer.Initialize(telemetry);
 
-            Assert.Equal("Production", telemetry.Context.GlobalProperties["AspNetCoreEnvironment"]);
+            Assert.Equal("Production", telemetry.Context.Properties["AspNetCoreEnvironment"]);
         }
     }
 }


### PR DESCRIPTION
- Swtich from Diagnostics adapters to listeners from @lmolkova (was already merged into develop, this commit is therefore ignored by PR);
- Switch from `Initialize()` to `InitializeInsturmenationKey()` to prevent second round of Telemetry Initializers
- `GetUri` updates, 2x gain ([this bug](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/862) is still an issue, though)
- `SetHeaderKeyValue` updates, 10x gain
- Use deprecated `Properties` for a while again to avoid second concurrent dictionary initialization for `GlobalProperties`.
- Test updates, including awesome contribution from @lmolkova to fix W3C correlation the aforementioned changes broke

For significant contributions please make sure you have completed the following items:

- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.