### PR TITLE
sdl fix System.Net.Security and System.Net.Http

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -86,6 +86,8 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ImportGroup Condition=" '$(OS)' == 'Windows_NT' ">


### PR DESCRIPTION
taking an explicit dependency on System.Net.Http will override any implicit dependencies.

Confirmed that this fixes the security scan.

I'm trying to copy @lmolkova's solution from here: https://github.com/microsoft/ApplicationInsights-dotnet/pull/1147

@lmolkova expressed some concerns about this in Web repo. Lets not merge until we resolve all concerns and agree this is the correct approach.