### PR TITLE
Add IJavaScriptSnippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## Version develop
+- [Fix: Add `IJavaScriptSnippet` service interface and update the `IServiceCollection` extension to register it for `JavaScriptSnippet`.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/890)
+
 ## Version 2.7.0
- - Updated Web/Base SDK version dependency to 2.10.0
+- Updated Web/Base SDK version dependency to 2.10.0
 - [Remove unused reference to System.Net.Http](https://github.com/microsoft/ApplicationInsights-aspnetcore/pull/879)
 
 ## Version 2.7.0-beta4

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -209,7 +209,8 @@
                     // AspNetCoreHostingDiagnosticListener injects TelemetryClient that injects TelemetryConfiguration
                     // that requires IOptions infrastructure to run and initialize
                     services.AddSingleton<IStartupFilter, ApplicationInsightsStartupFilter>();
-                    services.AddSingleton<JavaScriptSnippet>();
+                    services.AddSingleton<IJavaScriptSnippet, JavaScriptSnippet>();
+                    services.AddSingleton<JavaScriptSnippet>(); // Add 'JavaScriptSnippet' "Service" for backwards compatibility. To remove in favour of 'IJavaScriptSnippet'.
 
                     services.AddOptions();
                     services.AddSingleton<IOptions<TelemetryConfiguration>, TelemetryConfigurationOptions>();

--- a/src/Microsoft.ApplicationInsights.AspNetCore/IJavaScriptSnippet.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/IJavaScriptSnippet.cs
@@ -1,0 +1,14 @@
+namespace Microsoft.ApplicationInsights.AspNetCore
+{
+    /// <summary>
+    /// Represents factory used to generate Application Insights JavaScript snippet with dependency injection support.
+    /// </summary>
+    public interface IJavaScriptSnippet
+    {
+        /// <summary>
+        /// Gets a JavaScript code snippet including the 'script' tag.
+        /// </summary>
+        /// <returns>JavaScript code snippet.</returns>
+        string FullScript { get; }
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
@@ -11,7 +11,7 @@
     /// <summary>
     /// This class helps to inject Application Insights JavaScript snippet into application code.
     /// </summary>
-    public class JavaScriptSnippet
+    public class JavaScriptSnippet : IJavaScriptSnippet
     {
         /// <summary>JavaScript snippet.</summary>
         private static readonly string Snippet = Resources.JavaScriptSnippet;


### PR DESCRIPTION
Fix Issue #890 
Add `IJavaScriptSnippet` service interface and update the `IServiceCollection` extension to register it for `JavaScriptSnippet`.

Added the service registration alongside the original `services.AddSingleton<JavaScriptSnippet>()` to maintain backward compatibility.

- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [x] Design discussion issue #890
- [x] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
