### PR TITLE
Add option EnableAuthenticationTracking to add AuthenticatedUserId to telemetries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version develop
 - [Fix: Add `IJavaScriptSnippet` service interface and update the `IServiceCollection` extension to register it for `JavaScriptSnippet`.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/890)
+- [Added option EnableAuthenticationTracking to add AuthenticatedUserId to server-side telemetries](https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/894)
 
 ## Version 2.7.0
 - Updated Web/Base SDK version dependency to 2.10.0

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
@@ -102,6 +102,16 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         }
 
         /// <summary>
+        /// Logs an event for the AuthenticatedUserIdTelemetryInitializer OnInitializeTelemetry method when the AuthenticatedUserId is already set.
+        /// </summary>
+        /// <param name="appDomainName">An ignored placeholder to make EventSource happy.</param>
+        [Event(8, Message = "AuthenticatedUserIdTelemetryInitializer.OnInitializeTelemetry - telemetry.Context.User.AuthenticatedUserId is already set, returning.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
+        public void LogAuthenticatedUserIdTelemetryInitializerOnInitializeTelemetryAuthenticatedUserIdAlreadySet(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(8, this.ApplicationName);
+        }
+
+        /// <summary>
         /// Logs an event for the HostingDiagnosticListener OnHttpRequestInStart method when the current activity is null.
         /// </summary>
         /// <param name="appDomainName">An ignored placeholder to make EventSource happy.</param>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -119,6 +119,7 @@
                 o.ApplicationVersion = options.ApplicationVersion;
                 o.DeveloperMode = options.DeveloperMode;
                 o.EnableAdaptiveSampling = options.EnableAdaptiveSampling;
+                o.EnableAuthenticationTracking = options.EnableAuthenticationTracking;
                 o.EnableAuthenticationTrackingJavaScript = options.EnableAuthenticationTrackingJavaScript;
                 o.EnableDebugLogger = options.EnableDebugLogger;
                 o.EnableQuickPulseMetricStream = options.EnableQuickPulseMetricStream;
@@ -157,6 +158,7 @@
                     services.AddSingleton<ITelemetryInitializer, WebUserTelemetryInitializer>();
                     services.AddSingleton<ITelemetryInitializer, AspNetCoreEnvironmentTelemetryInitializer>();
                     services.AddSingleton<ITelemetryInitializer, HttpDependenciesParsingTelemetryInitializer>();
+                    services.AddSingleton<ITelemetryInitializer, AuthenticatedUserIdTelemetryInitializer>();
                     services.TryAddSingleton<ITelemetryChannel, ServerTelemetryChannel>();
 
                     services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>();

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
@@ -65,6 +65,7 @@
 
         /// <summary>
         /// Gets or sets a value indicating whether the currently authenticated user is added to telemetries or not.
+        /// This applies to server-side telemetry only, see <see cref="EnableAuthenticationTrackingJavaScript"/> for client-side telemetry.
         /// </summary>
         public bool EnableAuthenticationTracking { get; set; }
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsServiceOptions.cs
@@ -17,6 +17,7 @@
             this.EnableQuickPulseMetricStream = true;
             this.EnableAdaptiveSampling = true;
             this.EnableDebugLogger = true;
+            this.EnableAuthenticationTracking = false;
             this.EnableAuthenticationTrackingJavaScript = false;
             this.EnableHeartbeat = true;
             this.AddAutoCollectedMetricExtractor = true;
@@ -61,6 +62,11 @@
         /// Gets or sets a value indicating whether a logger would be registered automatically in debug mode.
         /// </summary>
         public bool EnableDebugLogger { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the currently authenticated user is added to telemetries or not.
+        /// </summary>
+        public bool EnableAuthenticationTracking { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether a JavaScript snippet to track the current authenticated user should

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AuthenticatedUserIdTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AuthenticatedUserIdTelemetryInitializer.cs
@@ -1,0 +1,45 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers
+{
+    using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Options;
+
+    /// <summary>
+    /// This initializer sets the Authenticated User Id if enabled via <see cref="ApplicationInsightsServiceOptions.EnableAuthenticationTracking"/>.
+    /// </summary>
+    public class AuthenticatedUserIdTelemetryInitializer : TelemetryInitializerBase
+    {
+        private readonly bool enabled;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticatedUserIdTelemetryInitializer" /> class.
+        /// </summary>
+        /// <param name="options">Provides the option <see cref="ApplicationInsightsServiceOptions.EnableAuthenticationTracking"/> indicating whether the currently authenticated user is added to telemetries or not.</param>
+        /// <param name="httpContextAccessor">Accessor to provide HttpContext corresponding to telemetry items.</param>
+        public AuthenticatedUserIdTelemetryInitializer(IOptions<ApplicationInsightsServiceOptions> options, IHttpContextAccessor httpContextAccessor)
+             : base(httpContextAccessor)
+        {
+            this.enabled = options.Value.EnableAuthenticationTracking;
+        }
+
+        /// <inheritdoc />
+        protected override void OnInitializeTelemetry(HttpContext platformContext, RequestTelemetry requestTelemetry, ITelemetry telemetry)
+        {
+            if (this.enabled)
+            {
+                if (string.IsNullOrEmpty(telemetry.Context.User.AuthenticatedUserId))
+                {
+                    var userIdentity = platformContext.User?.Identity;
+
+                    if (userIdentity != null &&
+                        userIdentity.IsAuthenticated)                    
+                    {
+                        telemetry.Context.User.AuthenticatedUserId = userIdentity.Name;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             [InlineData(typeof(ITelemetryInitializer), typeof(SyntheticTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(WebSessionTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(WebUserTelemetryInitializer), ServiceLifetime.Singleton)]
+            [InlineData(typeof(ITelemetryInitializer), typeof(AuthenticatedUserIdTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(TelemetryConfiguration), null, ServiceLifetime.Singleton)]
             [InlineData(typeof(TelemetryClient), typeof(TelemetryClient), ServiceLifetime.Singleton)]
             public static void RegistersExpectedServices(Type serviceType, Type implementationType, ServiceLifetime lifecycle)
@@ -80,6 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             [InlineData(typeof(ITelemetryInitializer), typeof(SyntheticTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(WebSessionTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(WebUserTelemetryInitializer), ServiceLifetime.Singleton)]
+            [InlineData(typeof(ITelemetryInitializer), typeof(AuthenticatedUserIdTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(TelemetryConfiguration), null, ServiceLifetime.Singleton)]
             [InlineData(typeof(TelemetryClient), typeof(TelemetryClient), ServiceLifetime.Singleton)]
             public static void RegistersExpectedServicesOnlyOnce(Type serviceType, Type implementationType, ServiceLifetime lifecycle)
@@ -454,6 +456,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                     ApplicationVersion = "test",
                     DeveloperMode = true,
                     EnableAdaptiveSampling = false,
+                    EnableAuthenticationTracking = false,
                     EnableAuthenticationTrackingJavaScript = false,
                     EnableDebugLogger = true,
                     EnableQuickPulseMetricStream = false,

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AuthenticatedUserIdTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AuthenticatedUserIdTelemetryInitializerTests.cs
@@ -1,0 +1,179 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
+{
+    using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+    using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
+    using Microsoft.ApplicationInsights.AspNetCore.Tests.Helpers;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Options;
+    using System;
+    using System.Security.Claims;
+    using Xunit;
+
+    public class AuthenticatedUserIdTelemetryInitializerTests
+    {
+        [Fact]
+        public void InitializeThrowIfHttpContextAccessorIsNull()
+        {
+            Assert.ThrowsAny<ArgumentNullException>(() =>
+            {
+                var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                    this.BuildConfigurationWithEnableAuthenticationTracking(),
+                    null);
+            });
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowIfHttpContextIsUnavailable()
+        {
+            var ac = new HttpContextAccessor()
+            {
+                HttpContext = null
+            };
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                ac);
+
+            initializer.Initialize(new RequestTelemetry());
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowIfRequestTelemetryIsUnavailable()
+        {
+            var ac = new HttpContextAccessor()
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                ac);
+
+            initializer.Initialize(new RequestTelemetry());
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowIfUserIsUnavailable()
+        {
+            var ac = BuildHttpContextAccessorWithoutUser();
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                ac);
+
+            initializer.Initialize(new RequestTelemetry());
+        }
+
+        [Fact]
+        public void InitializeAssignsAuthenticationIdToTelemetry()
+        {
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                this.BuildHttpContextAccessorWithAuthenticatedUser("TestAuthenticatedId"));
+
+            var telemetry = new RequestTelemetry();
+            initializer.Initialize(telemetry);
+
+            Assert.Equal("TestAuthenticatedId", telemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotOverrideExistingAuthenticationId()
+        {
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                this.BuildHttpContextAccessorWithAuthenticatedUser("TestOverriddenAuthenticationId"));
+
+            var telemetry = new RequestTelemetry();
+            telemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
+            initializer.Initialize(telemetry);
+
+            Assert.Equal("TestAuthenticationId", telemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotOverrideExistingAuthenticationIdIfUserNotAuthenticated()
+        {
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                this.BuildHttpContextAccessorWithoutUser());
+
+            var telemetry = new RequestTelemetry();
+            telemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
+            initializer.Initialize(telemetry);
+
+            Assert.Equal("TestAuthenticationId", telemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotAssignAuthenticationIdToTelemetryIfNotEnabled()
+        {
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(false),
+                this.BuildHttpContextAccessorWithAuthenticatedUser("TestAuthenticatedId"));
+
+            var telemetry = new RequestTelemetry();
+            initializer.Initialize(telemetry);
+
+            Assert.NotEqual("TestAuthenticatedId", telemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotOverrideExistingAuthenticationIdIfNotEnabled()
+        {
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(false),
+                this.BuildHttpContextAccessorWithAuthenticatedUser("TestOverriddenAuthenticationId"));
+
+            var telemetry = new RequestTelemetry();
+            telemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
+            initializer.Initialize(telemetry);
+
+            Assert.Equal("TestAuthenticationId", telemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotOverrideExistingAuthenticationIdIfUserNotAuthenticatedAndNotEnabled()
+        {
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(false),
+                this.BuildHttpContextAccessorWithoutUser());
+
+            var telemetry = new RequestTelemetry();
+            telemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
+            initializer.Initialize(telemetry);
+
+            Assert.Equal("TestAuthenticationId", telemetry.Context.User.AuthenticatedUserId);
+        }
+
+        private IOptions<ApplicationInsightsServiceOptions> BuildConfigurationWithEnableAuthenticationTracking(bool enableAuthenticationTracking = true)
+        {
+            return new OptionsWrapper<ApplicationInsightsServiceOptions>(new ApplicationInsightsServiceOptions()
+            {
+                EnableAuthenticationTracking = enableAuthenticationTracking
+            });
+        }
+
+        private IHttpContextAccessor BuildHttpContextAccessorWithAuthenticatedUser(string authUserId = "TestDefaultAuthenticationId")
+        {
+            var userIdentity = new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Name, authUserId) },
+                "TestAuthenticationType",
+                ClaimTypes.Name,
+                ClaimTypes.Role);
+
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), null);
+            contextAccessor.HttpContext.User = new ClaimsPrincipal(userIdentity);
+
+            return contextAccessor;
+        }
+
+        private IHttpContextAccessor BuildHttpContextAccessorWithoutUser()
+        {
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), null);
+
+            return contextAccessor;
+        }
+    }
+}

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AuthenticatedUserIdTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AuthenticatedUserIdTelemetryInitializerTests.cs
@@ -56,13 +56,27 @@
         [Fact]
         public void InitializeDoesNotThrowIfUserIsUnavailable()
         {
-            var ac = BuildHttpContextAccessorWithoutUser();
+            var ac = BuildHttpContextAccessorWithoutUser(new RequestTelemetry());
 
             var initializer = new AuthenticatedUserIdTelemetryInitializer(
                 this.BuildConfigurationWithEnableAuthenticationTracking(),
                 ac);
 
-            initializer.Initialize(new RequestTelemetry());
+            initializer.Initialize(new EventTelemetry());
+        }
+
+        [Fact]
+        public void InitializeAssignsAuthenticationIdToRequestTelemetry()
+        {
+            var requestTelemetry = new RequestTelemetry();
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                this.BuildHttpContextAccessorWithAuthenticatedUser(requestTelemetry, "TestAuthenticatedId"));
+
+            initializer.Initialize(new EventTelemetry());
+
+            Assert.Equal("TestAuthenticatedId", requestTelemetry.Context.User.AuthenticatedUserId);
         }
 
         [Fact]
@@ -70,22 +84,69 @@
         {
             var initializer = new AuthenticatedUserIdTelemetryInitializer(
                 this.BuildConfigurationWithEnableAuthenticationTracking(),
-                this.BuildHttpContextAccessorWithAuthenticatedUser("TestAuthenticatedId"));
+                this.BuildHttpContextAccessorWithAuthenticatedUser(new RequestTelemetry(), "TestAuthenticatedId"));
 
-            var telemetry = new RequestTelemetry();
+            var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry);
 
             Assert.Equal("TestAuthenticatedId", telemetry.Context.User.AuthenticatedUserId);
         }
 
         [Fact]
-        public void InitializeDoesNotOverrideExistingAuthenticationId()
+        public void InitializeAssignsExistingAuthenticatedUserIdFromRequestTelemetryToTelemetry()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            requestTelemetry.Context.User.AuthenticatedUserId = "TestAuthenticatedId";
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                this.BuildHttpContextAccessorWithAuthenticatedUser(requestTelemetry));
+
+            var telemetry = new EventTelemetry();
+            initializer.Initialize(telemetry);
+
+            Assert.Equal("TestAuthenticatedId", telemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotAssignAuthenticationIdToRequestTelemetryIfAuthenticatedUserIdAlreadySetOnTelemetry()
+        {
+            var requestTelemetry = new RequestTelemetry();
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                this.BuildHttpContextAccessorWithAuthenticatedUser(requestTelemetry));
+
+            var telemetry = new EventTelemetry();
+            telemetry.Context.User.AuthenticatedUserId = "TestAuthenticatedId";
+            initializer.Initialize(telemetry);
+
+            Assert.NotEqual("TestAuthenticatedId", requestTelemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotOverrideExistingAuthenticationIdOnRequestTelemetry()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            requestTelemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                this.BuildHttpContextAccessorWithAuthenticatedUser(requestTelemetry, "TestOverriddenAuthenticationId"));
+
+            initializer.Initialize(new EventTelemetry());
+
+            Assert.Equal("TestAuthenticationId", requestTelemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotOverrideExistingAuthenticationIdOnTelemetry()
         {
             var initializer = new AuthenticatedUserIdTelemetryInitializer(
                 this.BuildConfigurationWithEnableAuthenticationTracking(),
-                this.BuildHttpContextAccessorWithAuthenticatedUser("TestOverriddenAuthenticationId"));
+                this.BuildHttpContextAccessorWithAuthenticatedUser(new RequestTelemetry(), "TestOverriddenAuthenticationId"));
 
-            var telemetry = new RequestTelemetry();
+            var telemetry = new EventTelemetry();
             telemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
             initializer.Initialize(telemetry);
 
@@ -93,17 +154,46 @@
         }
 
         [Fact]
-        public void InitializeDoesNotOverrideExistingAuthenticationIdIfUserNotAuthenticated()
+        public void InitializeDoesNotOverrideExistingAuthenticationIdOnRequestTelemetryIfUserNotAuthenticated()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            requestTelemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(),
+                this.BuildHttpContextAccessorWithoutUser(requestTelemetry));
+
+            initializer.Initialize(new EventTelemetry());
+
+            Assert.Equal("TestAuthenticationId", requestTelemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotOverrideExistingAuthenticationIdOnTelemetryIfUserNotAuthenticated()
         {
             var initializer = new AuthenticatedUserIdTelemetryInitializer(
                 this.BuildConfigurationWithEnableAuthenticationTracking(),
-                this.BuildHttpContextAccessorWithoutUser());
+                this.BuildHttpContextAccessorWithoutUser(new RequestTelemetry()));
 
-            var telemetry = new RequestTelemetry();
+            var telemetry = new EventTelemetry();
             telemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
             initializer.Initialize(telemetry);
 
             Assert.Equal("TestAuthenticationId", telemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotAssignAuthenticationIdToRequestTelemetryIfNotEnabled()
+        {
+            var requestTelemetry = new RequestTelemetry();
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(false),
+                this.BuildHttpContextAccessorWithAuthenticatedUser(requestTelemetry, "TestAuthenticatedId"));
+
+            initializer.Initialize(new EventTelemetry());
+
+            Assert.NotEqual("TestAuthenticatedId", requestTelemetry.Context.User.AuthenticatedUserId);
         }
 
         [Fact]
@@ -111,22 +201,37 @@
         {
             var initializer = new AuthenticatedUserIdTelemetryInitializer(
                 this.BuildConfigurationWithEnableAuthenticationTracking(false),
-                this.BuildHttpContextAccessorWithAuthenticatedUser("TestAuthenticatedId"));
+                this.BuildHttpContextAccessorWithAuthenticatedUser(new RequestTelemetry(), "TestAuthenticatedId"));
 
-            var telemetry = new RequestTelemetry();
+            var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry);
 
             Assert.NotEqual("TestAuthenticatedId", telemetry.Context.User.AuthenticatedUserId);
         }
 
         [Fact]
-        public void InitializeDoesNotOverrideExistingAuthenticationIdIfNotEnabled()
+        public void InitializeDoesNotOverrideExistingAuthenticationIdOnRequestTelemetryIfNotEnabled()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            requestTelemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(false),
+                this.BuildHttpContextAccessorWithAuthenticatedUser(requestTelemetry, "TestOverriddenAuthenticationId"));
+
+            initializer.Initialize(new EventTelemetry());
+
+            Assert.Equal("TestAuthenticationId", requestTelemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotOverrideExistingAuthenticationIdOnTelemetryIfNotEnabled()
         {
             var initializer = new AuthenticatedUserIdTelemetryInitializer(
                 this.BuildConfigurationWithEnableAuthenticationTracking(false),
-                this.BuildHttpContextAccessorWithAuthenticatedUser("TestOverriddenAuthenticationId"));
+                this.BuildHttpContextAccessorWithAuthenticatedUser(new RequestTelemetry(), "TestOverriddenAuthenticationId"));
 
-            var telemetry = new RequestTelemetry();
+            var telemetry = new EventTelemetry();
             telemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
             initializer.Initialize(telemetry);
 
@@ -134,13 +239,28 @@
         }
 
         [Fact]
-        public void InitializeDoesNotOverrideExistingAuthenticationIdIfUserNotAuthenticatedAndNotEnabled()
+        public void InitializeDoesNotOverrideExistingAuthenticationIdOnRequestTelemetryIfUserNotAuthenticatedAndNotEnabled()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            requestTelemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
+
+            var initializer = new AuthenticatedUserIdTelemetryInitializer(
+                this.BuildConfigurationWithEnableAuthenticationTracking(false),
+                this.BuildHttpContextAccessorWithoutUser(requestTelemetry));
+
+            initializer.Initialize(new EventTelemetry());
+
+            Assert.Equal("TestAuthenticationId", requestTelemetry.Context.User.AuthenticatedUserId);
+        }
+
+        [Fact]
+        public void InitializeDoesNotOverrideExistingAuthenticationIdOnTelemetryIfUserNotAuthenticatedAndNotEnabled()
         {
             var initializer = new AuthenticatedUserIdTelemetryInitializer(
                 this.BuildConfigurationWithEnableAuthenticationTracking(false),
-                this.BuildHttpContextAccessorWithoutUser());
+                this.BuildHttpContextAccessorWithoutUser(new RequestTelemetry()));
 
-            var telemetry = new RequestTelemetry();
+            var telemetry = new EventTelemetry();
             telemetry.Context.User.AuthenticatedUserId = "TestAuthenticationId";
             initializer.Initialize(telemetry);
 
@@ -155,7 +275,7 @@
             });
         }
 
-        private IHttpContextAccessor BuildHttpContextAccessorWithAuthenticatedUser(string authUserId = "TestDefaultAuthenticationId")
+        private IHttpContextAccessor BuildHttpContextAccessorWithAuthenticatedUser(RequestTelemetry requestTelemetry, string authUserId = "TestDefaultAuthenticationId")
         {
             var userIdentity = new ClaimsIdentity(
                 new[] { new Claim(ClaimTypes.Name, authUserId) },
@@ -163,15 +283,15 @@
                 ClaimTypes.Name,
                 ClaimTypes.Role);
 
-            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), null);
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry, null);
             contextAccessor.HttpContext.User = new ClaimsPrincipal(userIdentity);
 
             return contextAccessor;
         }
 
-        private IHttpContextAccessor BuildHttpContextAccessorWithoutUser()
+        private IHttpContextAccessor BuildHttpContextAccessorWithoutUser(RequestTelemetry requestTelemetry)
         {
-            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), null);
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry, null);
 
             return contextAccessor;
         }


### PR DESCRIPTION
Proposed implementation for issue #894.

Adds a new option `EnableAuthenticationTracking` to `ApplicationInsightsServiceOptions` which can be enabled to add the authenticated user's `IIdentity.Name` to telemetries as `UserContext.AuthenticatedUserId`.

`UserContext.AuthenticatedUserId` is populated using newly introduced telemetry initializer `AuthenticatedUserIdTelemetryInitializer`.