### PR TITLE
ApplicationInsights StartupFilter should not swallow exceptions from …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Version develop
+## Version 2.8.0-beta1
 - [Fix: Add `IJavaScriptSnippet` service interface and update the `IServiceCollection` extension to register it for `JavaScriptSnippet`.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/890)
+- [Fix - ApplicationInsights StartupFilter should not swallow exceptions from downstream ApplicationBuilder.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/897)
 
 ## Version 2.7.0
 - Updated Web/Base SDK version dependency to 2.10.0

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ApplicationInsightsStartupFilter.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ApplicationInsightsStartupFilter.cs
@@ -23,12 +23,14 @@
                     // via <see cref="TelemetryConfigurationOptionsSetup"/> class which triggers
                     // initialization of TelemetryModules and construction of TelemetryProcessor pipeline.
                     var tc = app.ApplicationServices.GetService<TelemetryConfiguration>();
-                    next(app);
                 }
                 catch (Exception ex)
                 {
                     AspNetCoreEventSource.Instance.LogWarning(ex.Message);
                 }
+
+                // Invoking next builder is not wrapped in try catch to ensure any exceptions gets propogated up.
+                next(app);
             };
         }
     }


### PR DESCRIPTION
…downstream ApplicationBuilder

Fix Issue #897 

- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
