### PR TITLE
Improve slightly misleading comment for beginners

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -227,20 +227,25 @@
                         // The default behavior is to capture only logs above Warning level from all categories.
                         // This can achieved with this code level filter -> loggingBuilder.AddFilter<Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider>("",LogLevel.Warning);
                         // However, this will make it impossible to override this behavior from Configuration like below using appsettings.json:
-                        // "ApplicationInsights": {
-                        // "LogLevel": {
-                        // "": "Error"
+                        // {
+                        //   "Logging": {
+                        //     "ApplicationInsights": {
+                        //       "LogLevel": {
+                        //         "": "Error"
+                        //       }
+                        //     }
+                        //   },
+                        //   ...
                         // }
-                        // },
                         // The reason is as both rules will match the filter, the last one added wins.
                         // To ensure that the default filter is in the beginning of filter rules, so that user override from Configuration will always win,
                         // we add code filter rule to the 0th position as below.
-                         loggingBuilder.Services.Configure<LoggerFilterOptions>(
-                        options => options.Rules.Insert(
-                            0,
-                            new LoggerFilterRule(
-                                "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider", null,
-                                LogLevel.Warning, null)));
+                        loggingBuilder.Services.Configure<LoggerFilterOptions>(
+                            options => options.Rules.Insert(
+                                0,
+                                new LoggerFilterRule(
+                                    "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider", null,
+                                    LogLevel.Warning, null)));
                     });
 #endif
                 }


### PR DESCRIPTION
This only changes a code comment and code indent. The comment about how to override the LogLevel in appsettings.json did not make it clear that the required keys must appear within `Logging` in appsettings.json.

Fix Issue # N/A.
<Short description of the fix.> N/A

- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
