### PR TITLE
Make JavaScriptEncoder optional and Fallback to JavaScriptEncoder.Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version 2.8.0-beta1
 - [Fix: Add `IJavaScriptSnippet` service interface and update the `IServiceCollection` extension to register it for `JavaScriptSnippet`.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/890)
+- [Make JavaScriptEncoder optional and Fallback to JavaScriptEncoder.Default.](https://github.com/microsoft/ApplicationInsights-aspnetcore/pull/918)
+
+## Version 2.7.1
 - [Fix - ApplicationInsights StartupFilter should not swallow exceptions from downstream ApplicationBuilder.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/897)
 
 ## Version 2.7.0

--- a/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
@@ -46,7 +46,7 @@
             this.telemetryConfiguration = telemetryConfiguration;
             this.httpContextAccessor = httpContextAccessor;
             this.enableAuthSnippet = serviceOptions.Value.EnableAuthenticationTrackingJavaScript;
-            this.encoder = encoder;
+            this.encoder = (encoder == null) ? JavaScriptEncoder.Default : encoder;
         }
 
         /// <summary>
@@ -62,11 +62,10 @@
                 {
                     string additionalJS = string.Empty;
                     IIdentity identity = this.httpContextAccessor?.HttpContext?.User?.Identity;
-                    if (enableAuthSnippet &&
-                        this.encoder != null &&
+                    if (enableAuthSnippet &&                        
                         identity != null &&
                         identity.IsAuthenticated)
-                    {
+                    {                        
                         string escapedUserName = encoder.Encode(identity.Name);
                         additionalJS = string.Format(CultureInfo.InvariantCulture, AuthSnippet, escapedUserName);
                     }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
@@ -62,10 +62,10 @@
                 {
                     string additionalJS = string.Empty;
                     IIdentity identity = this.httpContextAccessor?.HttpContext?.User?.Identity;
-                    if (enableAuthSnippet &&                        
+                    if (enableAuthSnippet &&
                         identity != null &&
                         identity.IsAuthenticated)
-                    {                        
+                    {
                         string escapedUserName = encoder.Encode(identity.Name);
                         additionalJS = string.Format(CultureInfo.InvariantCulture, AuthSnippet, escapedUserName);
                     }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
@@ -41,7 +41,7 @@
             TelemetryConfiguration telemetryConfiguration,
             IOptions<ApplicationInsightsServiceOptions> serviceOptions,
             IHttpContextAccessor httpContextAccessor,
-            JavaScriptEncoder encoder)
+            JavaScriptEncoder encoder = null)
         {
             this.telemetryConfiguration = telemetryConfiguration;
             this.httpContextAccessor = httpContextAccessor;
@@ -63,6 +63,7 @@
                     string additionalJS = string.Empty;
                     IIdentity identity = this.httpContextAccessor?.HttpContext?.User?.Identity;
                     if (enableAuthSnippet &&
+                        this.encoder != null &&
                         identity != null &&
                         identity.IsAuthenticated)
                     {


### PR DESCRIPTION
Fix Issue #502  .

This fix to make application insights work in web api apps in .netcore 3.0, as web encoders are not present in web api.

Once test infra has 3.0, need to add functional test to ensure apps dont crash if no encoder present.

- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
