### PR TITLE
Nullcheck for httpcontext.request in telemetry initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.8.0-beta2
+- [Add Null check for HttpContext>Request](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/903)
+
 ## Version 2.8.0-beta1
 - [Add EventCounter collection.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/913)
 - [Performance fixes: One DiagSource Listener; Head Sampling Feature; No Concurrent Dictionary; etc...](https://github.com/microsoft/ApplicationInsights-aspnetcore/pull/907)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/WebSessionTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/WebSessionTelemetryInitializer.cs
@@ -43,7 +43,7 @@
 
         private static void UpdateRequestTelemetryFromPlatformContext(RequestTelemetry requestTelemetry, HttpContext platformContext)
         {
-            if (platformContext.Request.Cookies != null && platformContext.Request.Cookies.ContainsKey(WebSessionCookieName))
+            if (platformContext.Request?.Cookies != null && platformContext.Request.Cookies.ContainsKey(WebSessionCookieName))
             {
                 var sessionCookieValue = platformContext.Request.Cookies[WebSessionCookieName];
                 if (!string.IsNullOrEmpty(sessionCookieValue))

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/WebUserTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/WebUserTelemetryInitializer.cs
@@ -43,7 +43,7 @@
 
         private static void UpdateRequestTelemetryFromPlatformContext(RequestTelemetry requestTelemetry, HttpContext platformContext)
         {
-            if (platformContext.Request.Cookies != null && platformContext.Request.Cookies.ContainsKey(WebUserCookieName))
+            if (platformContext.Request?.Cookies != null && platformContext.Request.Cookies.ContainsKey(WebUserCookieName))
             {
                 var userCookieValue = platformContext.Request.Cookies[WebUserCookieName];
                 if (!string.IsNullOrEmpty(userCookieValue))


### PR DESCRIPTION
Fix Issue #903.
<Short description of the fix.>

- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
