### PR TITLE
nupkg.props

### DIFF
--- a/ApplicationInsights.AspNetCore.sln
+++ b/ApplicationInsights.AspNetCore.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Common.targets = Common.targets
 		dirs.proj = dirs.proj
 		NuGet.config = NuGet.config
+		Nupkg.props = Nupkg.props
 		Readme.md = Readme.md
 		RunTestsCore.ps1 = RunTestsCore.ps1
 		SetEnv.targets = SetEnv.targets

--- a/Nupkg.props
+++ b/Nupkg.props
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="$(OS) == 'Windows_NT'">
+    <!-- Including this file will generate both the *.nupkg and *.symbols.nupkg -->
+    <!--https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg-->
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- These are the common properties used when generating the nupkg -->
+    <!-- https://docs.microsoft.com/en-us/nuget/schema/msbuild-targets -->
+    <Company>Microsoft</Company>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <!-- <PackageVersion>Defined in GlobalStaticVersion.props</PackageVersion> -->
+    <Authors>Microsoft</Authors>
+    <Owners>Microsoft,AppInsightsSdk</Owners>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://go.microsoft.com/fwlink/?LinkId=392727</PackageProjectUrl>
+    <PackageIconUrl>https://appanacdn.blob.core.windows.net/cdn/icons/aic.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/Microsoft/applicationinsights-aspnetcore</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+    <PackageType>Dependency</PackageType>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <PackageReleaseNotes>For the release notes please follow http://go.microsoft.com/fwlink/?LinkId=535037</PackageReleaseNotes>
+    <!-- <PackageOutputPath>Defined in Directory.Build.props</PackageOutputPath> -->
+    <PackageTags>Azure;Monitoring;Analytics;ApplicationInsights;Telemetry;AppInsights;aspnetcore;</PackageTags>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- These Properties are unique to the project and must be set in the csproj -->
+    <PackageId>UNDEFINED</PackageId>
+    <Title>UNDEFINED</Title>
+    <Description>UNDEFINED</Description>
+    <!-- <PackageTags>$(PackageTags) newTag1 newTag2</PackageTags> -->
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Disable auto generation of package attributes. This resolves the 'Duplicate attribute' error. 
+         Common cause is a hidden AssemblyInfo.cs file in a project -->
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -1,4 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\Nupkg.props" />
+  
   <PropertyGroup>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore</AssemblyName>
     <VersionPrefix>2.8.0-beta1</VersionPrefix>
@@ -19,22 +21,6 @@
     <Description>Application Insights for ASP.NET Core web applications. See https://azure.microsoft.com/documentation/articles/app-insights-asp-net-five/ for more information. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!--Normalized Nupkg properties. I will remove this PropertyGroup in a follow up PR.-->
-    <Authors>Microsoft</Authors>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/Microsoft/ApplicationInsights-aspnetcore.git</RepositoryUrl>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <IncludeSymbols>True</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageTags>Azure;Monitoring;Analytics;ApplicationInsights;Telemetry;AppInsights;aspnetcore;</PackageTags>
-    <PackageIconUrl>https://appanacdn.blob.core.windows.net/cdn/icons/aic.png</PackageIconUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://go.microsoft.com/fwlink/?LinkId=392727</PackageProjectUrl>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-  </PropertyGroup>
-  
   <PropertyGroup>
     <!--Package Settings-->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Moving generic properties to the nupkg.props file.
This is for consistency across all our repos.