### PR TITLE
Remove x-ms based correlation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.8.0-beta2
 - [Obsolete extension methods on IWebHostBuilder in favor of AddApplicationInsights extension method on IServiceCollection.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/919)
+- [Remove support for deprecated x-ms based correlation headers.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/939)
 
 ## Version 2.8.0-beta1
 - [Add EventCounter collection.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/913)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/RequestResponseHeaders.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/RequestResponseHeaders.cs
@@ -21,16 +21,6 @@
         public const string RequestContextTargetKey = "appId"; // Although the name of Source and Target key is the same - appId. Conceptually they are different and hence, we intentionally have two constants here. Makes for better reading of the code.
 
         /// <summary>
-        /// Standard parent Id header.
-        /// </summary>
-        public const string StandardParentIdHeader = "x-ms-request-id";
-
-        /// <summary>
-        /// Standard root id header.
-        /// </summary>
-        public const string StandardRootIdHeader = "x-ms-request-root-id";
-
-        /// <summary>
         /// Request-Id header.
         /// </summary>
         public const string RequestIdHeader = "Request-Id";

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
@@ -22,6 +22,7 @@
     {
         private const string HttpRequestScheme = "http";
         private const string ExpectedAppId = "cid-v1:some-app-id";
+        private const string ActivityCreatedByHostingDiagnosticListener = "ActivityCreatedByHostingDiagnosticListener";
 
         private static readonly HostString HttpRequestHost = new HostString("testHost");
         private static readonly PathString HttpRequestPath = new PathString("/path/path");
@@ -102,10 +103,12 @@
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void TestSdkVersionIsPopulatedByMiddleware(bool isAspNetCore2)
+        public void TestConditionalAppIdFlagIsRespected(bool isAspNetCore2)
         {
             HttpContext context = CreateContext(HttpRequestScheme, HttpRequestHost);
             TelemetryConfiguration config = TelemetryConfiguration.CreateDefault();
+            // This flag tells sdk to not add app id in response header, unless its received in incoming headers.
+            // For tests, no incoming headers is add, so the response should not have app id as well.
             config.ExperimentalFeatures.Add("conditionalAppId");
 
             using (var hostingListener = CreateHostingListener(isAspNetCore2, config))
@@ -114,9 +117,39 @@
 
                 Assert.NotNull(context.Features.Get<RequestTelemetry>());
 
+                // VALIDATE
                 Assert.Null(HttpHeadersUtilities.GetRequestContextKeyValue(context.Response.Headers,
                         RequestResponseHeaders.RequestContextTargetKey));
 
+                HandleRequestEnd(hostingListener, context, 0, isAspNetCore2);
+            }
+
+            Assert.Single(sentTelemetry);
+            Assert.IsType<RequestTelemetry>(this.sentTelemetry.First());
+
+            RequestTelemetry requestTelemetry = this.sentTelemetry.First() as RequestTelemetry;
+            Assert.True(requestTelemetry.Duration.TotalMilliseconds >= 0);
+            Assert.True(requestTelemetry.Success);
+            Assert.Equal(CommonMocks.InstrumentationKey, requestTelemetry.Context.InstrumentationKey);
+            Assert.True(string.IsNullOrEmpty(requestTelemetry.Source));
+            Assert.Equal(CreateUri(HttpRequestScheme, HttpRequestHost), requestTelemetry.Url);
+            Assert.NotEmpty(requestTelemetry.Context.GetInternalContext().SdkVersion);
+            Assert.Contains(SdkVersionTestUtils.VersionPrefix, requestTelemetry.Context.GetInternalContext().SdkVersion);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TestSdkVersionIsPopulatedByMiddleware(bool isAspNetCore2)
+        {
+            HttpContext context = CreateContext(HttpRequestScheme, HttpRequestHost);
+            TelemetryConfiguration config = TelemetryConfiguration.CreateDefault();
+
+            using (var hostingListener = CreateHostingListener(isAspNetCore2, config))
+            {
+                HandleRequestBegin(hostingListener, context, 0, isAspNetCore2);
+
+                Assert.NotNull(context.Features.Get<RequestTelemetry>());
                 HandleRequestEnd(hostingListener, context, 0, isAspNetCore2);
             }
 
@@ -186,7 +219,7 @@
             var telemetries = sentTelemetry.ToArray();
             Assert.Equal(2, sentTelemetry.Count);
             Assert.IsType<ExceptionTelemetry>(telemetries[0]);
-
+            
             Assert.IsType<RequestTelemetry>(telemetries[1]);
             RequestTelemetry requestTelemetry = telemetries[1] as RequestTelemetry;
             Assert.True(requestTelemetry.Duration.TotalMilliseconds >= 0);
@@ -210,6 +243,7 @@
                 HandleRequestBegin(hostingListener, context, 0, isAspNetCore2);
 
                 Assert.NotNull(Activity.Current);
+                Assert.Equal(ActivityCreatedByHostingDiagnosticListener, Activity.Current.OperationName);
 
                 var requestTelemetry = context.Features.Get<RequestTelemetry>();
                 Assert.NotNull(requestTelemetry);
@@ -224,31 +258,6 @@
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void OnBeginRequestCreateNewActivityAndInitializeRequestTelemetryFromStandardHeader(bool isAspNetCore2)
-        {
-            HttpContext context = CreateContext(HttpRequestScheme, HttpRequestHost, "/Test", method: "POST");
-            var standardRequestId = Guid.NewGuid().ToString();
-            var standardRequestRootId = Guid.NewGuid().ToString();
-            context.Request.Headers[RequestResponseHeaders.StandardParentIdHeader] = standardRequestId;
-            context.Request.Headers[RequestResponseHeaders.StandardRootIdHeader] = standardRequestRootId;
-
-            using (var hostingListener = CreateHostingListener(isAspNetCore2))
-            {
-                HandleRequestBegin(hostingListener, context, 0, isAspNetCore2);
-
-                Assert.NotNull(Activity.Current);
-
-                var requestTelemetry = context.Features.Get<RequestTelemetry>();
-                Assert.NotNull(requestTelemetry);
-                Assert.Equal(requestTelemetry.Id, Activity.Current.Id);
-                Assert.Equal(requestTelemetry.Context.Operation.Id, standardRequestRootId);
-                Assert.Equal(requestTelemetry.Context.Operation.ParentId, standardRequestId);
-            }
-        }
-
         [Fact]
         public void OnBeginRequestCreateNewActivityAndInitializeRequestTelemetryFromRequestIdHeader()
         {
@@ -257,8 +266,6 @@
             var standardRequestId = Guid.NewGuid().ToString();
             var standardRequestRootId = Guid.NewGuid().ToString();
             context.Request.Headers[RequestResponseHeaders.RequestIdHeader] = requestId;
-            context.Request.Headers[RequestResponseHeaders.StandardParentIdHeader] = standardRequestId;
-            context.Request.Headers[RequestResponseHeaders.StandardRootIdHeader] = standardRequestRootId;
             context.Request.Headers[RequestResponseHeaders.CorrelationContextHeader] = "prop1=value1, prop2=value2";
 
             using (var hostingListener = CreateHostingListener(false))
@@ -276,8 +283,8 @@
                 Assert.NotEqual(requestTelemetry.Context.Operation.Id, standardRequestRootId);
                 Assert.Equal(requestTelemetry.Context.Operation.ParentId, requestId);
                 Assert.NotEqual(requestTelemetry.Context.Operation.ParentId, standardRequestId);
-                Assert.Equal("value1", requestTelemetry.Context.Properties["prop1"]);
-                Assert.Equal("value2", requestTelemetry.Context.Properties["prop2"]);
+                Assert.Equal("value1", requestTelemetry.Properties["prop1"]);
+                Assert.Equal("value2", requestTelemetry.Properties["prop2"]);
             }
         }
 
@@ -310,39 +317,6 @@
             {
                 Assert.True(requestTelemetry.Properties.ContainsKey(prop.Key));
                 Assert.Equal(requestTelemetry.Properties[prop.Key], prop.Value);
-            }
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void OnHttpRequestInStartCreateNewActivityIfParentIdIsNullAndHasStandardHeader(bool isAspNetCore2)
-        {
-            var context = CreateContext(HttpRequestScheme, HttpRequestHost, "/Test", method: "POST");
-            var standardRequestId = Guid.NewGuid().ToString();
-            var standardRequestRootId = Guid.NewGuid().ToString();
-            context.Request.Headers[RequestResponseHeaders.StandardParentIdHeader] = standardRequestId;
-            context.Request.Headers[RequestResponseHeaders.StandardRootIdHeader] = standardRequestRootId;
-
-            var activity = new Activity("operation");
-            activity.Start();
-
-            using (var hostingListener = CreateHostingListener(isAspNetCore2))
-            {
-                HandleRequestBegin(hostingListener, context, 0, isAspNetCore2);
-
-                var activityInitializedByStandardHeader = Activity.Current;
-                Assert.NotEqual(activityInitializedByStandardHeader, activity);
-                Assert.Equal(activityInitializedByStandardHeader.ParentId, standardRequestRootId);
-
-                HandleRequestEnd(hostingListener, context, 0, isAspNetCore2);
-
-                Assert.Single(sentTelemetry);
-                var requestTelemetry = this.sentTelemetry.First() as RequestTelemetry;
-
-                Assert.Equal(requestTelemetry.Id, activityInitializedByStandardHeader.Id);
-                Assert.Equal(requestTelemetry.Context.Operation.Id, standardRequestRootId);
-                Assert.Equal(requestTelemetry.Context.Operation.ParentId, standardRequestId);
             }
         }
 
@@ -979,6 +953,8 @@
                 {
                     var activity = new Activity("operation");
 
+                    // Simulating the behaviour of Hosting layer in 2.xx, which parses Request-Id Header and 
+                    // set Activity parent.
                     if (context.Request.Headers.TryGetValue("Request-Id", out var requestId))
                     {
                         activity.SetParentId(requestId);

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netcoreapp2.0;net46;netcoreapp1.0</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore.Tests</AssemblyName>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFrameworks>net46;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46;netcoreapp1.0</TargetFrameworks>
+	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore.Tests</AssemblyName>


### PR DESCRIPTION
Fix Issue #939  .
Also made minor improvements to unit tests as well.

- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Changes in public surface reviewed
- [ ] Design discussion issue #
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/develop/Readme.md) instructions to build and test locally.
