### PR TITLE
Fix spelling after merge

### DIFF
--- a/Schema/PublicSchema/ContextTagKeys.bond
+++ b/Schema/PublicSchema/ContextTagKeys.bond
@@ -70,7 +70,7 @@ struct ContextTagKeys
     [MaxStringLength("1024")]
     505: string 	 UserAccountId = "ai.user.accountId";
     
-    [Description("The browser's user agent string as reported by the browser. This property will be used to extract informaiton regarding the customer's browser but will not be stored. Use custom properties to store the original user agent.")]
+    [Description("The browser's user agent string as reported by the browser. This property will be used to extract information regarding the customer's browser but will not be stored. Use custom properties to store the original user agent.")]
     [MaxStringLength("2048")]
     510: string 	 UserAgent = "ai.user.userAgent";
     
@@ -86,7 +86,7 @@ struct ContextTagKeys
     [MaxStringLength("256")]
     705: string 	 CloudRole = "ai.cloud.role";
     
-    [Description("Name of the instance where the application is running. Computer name for on-premisis, instance name for Azure.")]
+    [Description("Name of the instance where the application is running. Computer name for on-premises, instance name for Azure.")]
     [MaxStringLength("256")]
     715: string 	 CloudRoleInstance = "ai.cloud.roleInstance";
     

--- a/Schema/PublicSchema/MessageData.bond
+++ b/Schema/PublicSchema/MessageData.bond
@@ -3,7 +3,7 @@ import "SeverityLevel.bond"
 
 namespace AI
 
-[Description("Instances of Message represent printf-like trace statements that are text-searched. Log4Net, NLog and other text-based log file entries are translated into intances of this type. The message does not have measurements.")]
+[Description("Instances of Message represent printf-like trace statements that are text-searched. Log4Net, NLog and other text-based log file entries are translated into instances of this type. The message does not have measurements.")]
 struct MessageData
     : Domain
 {

--- a/Schema/PublicSchema/RemoteDependencyData.bond
+++ b/Schema/PublicSchema/RemoteDependencyData.bond
@@ -26,7 +26,7 @@ struct RemoteDependencyData
     [ActAsRequired("Renaming value to duration.")]
     61: required string 	 duration;
     
-    [Description("Indication of successfull or unsuccessfull call.")]
+    [Description("Indication of successful or unsuccessful call.")]
     120: bool	 success = true;
     
     [MaxStringLength("8192")]

--- a/Schema/PublicSchema/RequestData.bond
+++ b/Schema/PublicSchema/RequestData.bond
@@ -21,7 +21,7 @@ struct RequestData
     [Description("Result of a request execution. HTTP status code for HTTP requests.")]
     60: required string 	 responseCode;
     
-    [Description("Indication of successfull or unsuccessfull call.")]
+    [Description("Indication of successful or unsuccessful call.")]
     70: required bool 	 success;
     
     [MaxStringLength("1024")]

--- a/test/ApplicationInsightsTypes/Generated/ContextTagKeys_types.cs
+++ b/test/ApplicationInsightsTypes/Generated/ContextTagKeys_types.cs
@@ -115,7 +115,7 @@ namespace AI
         [global::Bond.Id(505)]
         public string UserAccountId { get; set; }
 
-        [global::Bond.Attribute("Description", "The browser's user agent string as reported by the browser. This property will be used to extract informaiton regarding the customer's browser but will not be stored. Use custom properties to store the original user agent.")]
+        [global::Bond.Attribute("Description", "The browser's user agent string as reported by the browser. This property will be used to extract information regarding the customer's browser but will not be stored. Use custom properties to store the original user agent.")]
         [global::Bond.Attribute("MaxStringLength", "2048")]
         [global::Bond.Id(510)]
         public string UserAgent { get; set; }
@@ -135,7 +135,7 @@ namespace AI
         [global::Bond.Id(705)]
         public string CloudRole { get; set; }
 
-        [global::Bond.Attribute("Description", "Name of the instance where the application is running. Computer name for on-premisis, instance name for Azure.")]
+        [global::Bond.Attribute("Description", "Name of the instance where the application is running. Computer name for on-premises, instance name for Azure.")]
         [global::Bond.Attribute("MaxStringLength", "256")]
         [global::Bond.Id(715)]
         public string CloudRoleInstance { get; set; }

--- a/test/ApplicationInsightsTypes/Generated/MessageData_types.cs
+++ b/test/ApplicationInsightsTypes/Generated/MessageData_types.cs
@@ -28,7 +28,7 @@ namespace AI
 {
     using System.Collections.Generic;
 
-    [global::Bond.Attribute("Description", "Instances of Message represent printf-like trace statements that are text-searched. Log4Net, NLog and other text-based log file entries are translated into intances of this type. The message does not have measurements.")]
+    [global::Bond.Attribute("Description", "Instances of Message represent printf-like trace statements that are text-searched. Log4Net, NLog and other text-based log file entries are translated into instances of this type. The message does not have measurements.")]
     [global::Bond.Schema]
     [System.CodeDom.Compiler.GeneratedCode("gbc", "0.10.1.0")]
     public partial class MessageData

--- a/test/ApplicationInsightsTypes/Generated/RemoteDependencyData_types.cs
+++ b/test/ApplicationInsightsTypes/Generated/RemoteDependencyData_types.cs
@@ -59,7 +59,7 @@ namespace AI
         [global::Bond.Id(61), global::Bond.Required]
         public string duration { get; set; }
 
-        [global::Bond.Attribute("Description", "Indication of successfull or unsuccessfull call.")]
+        [global::Bond.Attribute("Description", "Indication of successful or unsuccessful call.")]
         [global::Bond.Id(120)]
         public bool success { get; set; }
 

--- a/test/ApplicationInsightsTypes/Generated/RequestData_types.cs
+++ b/test/ApplicationInsightsTypes/Generated/RequestData_types.cs
@@ -58,7 +58,7 @@ namespace AI
         [global::Bond.Id(60), global::Bond.Required]
         public string responseCode { get; set; }
 
-        [global::Bond.Attribute("Description", "Indication of successfull or unsuccessfull call.")]
+        [global::Bond.Attribute("Description", "Indication of successful or unsuccessful call.")]
         [global::Bond.Id(70), global::Bond.Required]
         public bool success { get; set; }
 


### PR DESCRIPTION
Good people commented on my previous pool request after it was already completed that automated merge of my branch and develop overwrote some spelling fixes we already had in tests.

Restoring the right spelling back.