### PR TITLE
Do not set sampledOut flag if activity is recorded and parentId fixes

### DIFF
--- a/test/TestApp30.Tests/BasicTestWithCorrelation.cs
+++ b/test/TestApp30.Tests/BasicTestWithCorrelation.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -65,7 +63,7 @@ namespace TestApp30.Tests
             Assert.NotNull(trace);
 
             Assert.Equal("4e3083444c10254ba40513c7316332eb", req.Context.Operation.Id);
-            Assert.Equal("00-4e3083444c10254ba40513c7316332eb-e2a5f830c0ee2c46-00", req.Context.Operation.ParentId);
+            Assert.Equal("|4e3083444c10254ba40513c7316332eb.e2a5f830c0ee2c46.", req.Context.Operation.ParentId);
             Assert.Equal("4e3083444c10254ba40513c7316332eb", trace.Context.Operation.Id);
             Assert.Contains("|4e3083444c10254ba40513c7316332eb.", req.Id);
             Assert.Equal(req.Id, trace.Context.Operation.ParentId);
@@ -111,7 +109,7 @@ namespace TestApp30.Tests
 
             Assert.Equal("4e3083444c10254ba40513c7316332eb", req.Context.Operation.Id);
             Assert.Equal("4e3083444c10254ba40513c7316332eb", exception.Context.Operation.Id);
-            Assert.Equal("00-4e3083444c10254ba40513c7316332eb-e2a5f830c0ee2c46-00", req.Context.Operation.ParentId);
+            Assert.Equal("|4e3083444c10254ba40513c7316332eb.e2a5f830c0ee2c46.", req.Context.Operation.ParentId);
             Assert.Equal(req.Id, exception.Context.Operation.ParentId);
             Assert.Contains("|4e3083444c10254ba40513c7316332eb.", req.Id);
 

--- a/test/WebApi20.FunctionalTests/FunctionalTest/RequestCorrelationTests.cs
+++ b/test/WebApi20.FunctionalTests/FunctionalTest/RequestCorrelationTests.cs
@@ -214,7 +214,7 @@
                 var actualRequest = this.ValidateRequestWithHeaders(server, RequestPath, headers, expectedRequestTelemetry);
 
                 Assert.Equal("4bf92f3577b34da6a3ce929d0e0e4736", actualRequest.tags["ai.operation.id"]);
-                Assert.Contains("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", actualRequest.tags["ai.operation.parentId"]);
+                Assert.Equal("|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.", actualRequest.tags["ai.operation.parentId"]);
 
                 // Correlation-Context will be read if either Request-Id or TraceParent available.
                 Assert.True(actualRequest.data.baseData.properties.ContainsKey("k1"));
@@ -261,7 +261,7 @@
 
                 Assert.Equal("4bf92f3577b34da6a3ce929d0e0e4736", actualRequest.tags["ai.operation.id"]);
                 Assert.NotEqual("8ee8641cbdd8dd280d239fa2121c7e4e", actualRequest.tags["ai.operation.id"]);
-                Assert.Contains("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", actualRequest.tags["ai.operation.parentId"]);
+                Assert.Equal("|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.", actualRequest.tags["ai.operation.parentId"]);
 
                 // Correlation-Context will be read if either Request-Id or traceparent is present.
                 Assert.True(actualRequest.data.baseData.properties.ContainsKey("k1"));


### PR DESCRIPTION
If Activity is recorded, we are going to sample in proactively (i.e. give more weight for these items, see https://github.com/Microsoft/ApplicationInsights-dotnet/pull/1200)

When we proactively sample features out, we should check Activity.Recorded first and only sample out those which are not recorded.

Also, I noticed parent -id on requests is not set correctly in W3C format. fixing that.