### PR TITLE
bump version 2.8.0-beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Non Product - Asp.Net Core 3.0 Functional Tests Added. This leverages the built-in integration test capability of ASP.NET Core via Microsoft.AspNetCore.MVC.Testing](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/539)
 - [Fix: System.NullReferenceException in WebSessionTelemetryInitializer.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/903)
 - Updated Base SDK version dependency to 2.11.0-beta2
+- Updated System.Diagnostics.DiagnosticSource to 4.6.0-preview8.
 
 ## Version 2.8.0-beta2
 - [Fix MVCBeforeAction property fetcher to work with .NET Core 3.0 changes.](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/936)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -74,13 +74,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.11.0-beta2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.11.0-beta1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.11.0-beta1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.11.0-beta1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.11.0-beta2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.11.0-beta2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.11.0-beta2" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.11.0-beta2" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.0.2" />           
     <PackageReference Include="System.Text.Encodings.Web" Version="4.3.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview7.19362.9" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview8.19405.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">

--- a/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
+++ b/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
@@ -48,7 +48,6 @@
             }
         }
         
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TestMixedTelemetryItemsReceived()
         {
             InProcessServer server;

--- a/test/EmptyApp.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
+++ b/test/EmptyApp.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
@@ -12,7 +12,6 @@
         }
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.
 
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TestBasicDependencyPropertiesAfterRequestingBasicPage()
         {
             this.ValidateBasicDependency(assemblyName, "/");

--- a/test/EmptyApp20.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
+++ b/test/EmptyApp20.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
@@ -63,7 +63,6 @@
             }
         }
 
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TestMixedTelemetryItemsReceived()
         {
             using (var server = new InProcessServer(assemblyName, this.output))

--- a/test/EmptyApp20.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
+++ b/test/EmptyApp20.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
@@ -14,7 +14,6 @@
 
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.
 
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TestBasicDependencyPropertiesAfterRequestingBasicPage()
         {
             const string RequestPath = "/";

--- a/test/MVCFramework.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
+++ b/test/MVCFramework.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
@@ -68,7 +68,6 @@ namespace MVCFramework.FunctionalTests.FunctionalTest
             }
         }
 
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TestMixedTelemetryItemsReceived()
         {
             InProcessServer server;

--- a/test/MVCFramework.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
+++ b/test/MVCFramework.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
@@ -14,7 +14,6 @@
 
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.
         
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TestBasicDependencyPropertiesAfterRequestingBasicPage()
         {
             this.ValidateBasicDependency(assemblyName, "/Home/About/5", InProcessServer.UseApplicationInsights);

--- a/test/MVCFramework20.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
+++ b/test/MVCFramework20.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
@@ -87,7 +87,6 @@
             }
         }
 
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TestMixedTelemetryItemsReceived()
         {
             using (var server = new InProcessServer(assemblyName, this.output))

--- a/test/MVCFramework20.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
+++ b/test/MVCFramework20.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
@@ -15,7 +15,6 @@
 
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.
 
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TestBasicDependencyPropertiesAfterRequestingBasicPage()
         {
             const string RequestPath = "/Home/About/5";

--- a/test/WebApi.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
+++ b/test/WebApi.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
@@ -15,7 +15,6 @@ namespace WebApi.FunctionalTests.FunctionalTest
         }
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.
 
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
 
         public void TestBasicDependencyPropertiesAfterRequestingBasicPage()
         {

--- a/test/WebApi20.FunctionalTests/FunctionalTest/MultipleWebHostsTests.cs
+++ b/test/WebApi20.FunctionalTests/FunctionalTest/MultipleWebHostsTests.cs
@@ -19,7 +19,6 @@ namespace WebApi20.FuncTests
         {
         }
 
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TwoWebHostsCreatedSequentially()
         {
             using (var server1 = new InProcessServer(assemblyName, this.output))
@@ -51,7 +50,6 @@ namespace WebApi20.FuncTests
             }
         }
 
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TwoWebHostsCreatedInParallel()
         {
             using (var server1 = new InProcessServer(assemblyName, this.output))

--- a/test/WebApi20.FunctionalTests/FunctionalTest/RequestDependencyCorrelationTests.cs
+++ b/test/WebApi20.FunctionalTests/FunctionalTest/RequestDependencyCorrelationTests.cs
@@ -21,7 +21,6 @@
 
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.
 
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TestBasicDependencyPropertiesAfterRequestingBasicPage()
         {
             const string RequestPath = "/api/values";
@@ -39,7 +38,6 @@
         }
 
         // We may need to add more tests to cover Request + Dependency Tracking
-        [Fact(Skip = "Re-Enable once DependencyTrackingModule is updated to latest DiagnosticSource.")]
         public void TestDependencyAndRequestWithW3CStandard()
         {
             const string RequestPath = "/api/values";


### PR DESCRIPTION
also updated DiagnosticSource to stay in sync with WebSDK https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/1252