### PR TITLE
refactor ApplicationInsightsServiceOptions

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -109,19 +109,7 @@
             ApplicationInsightsServiceOptions options)
         {
             services.AddApplicationInsightsTelemetry();
-            services.Configure((ApplicationInsightsServiceOptions o) =>
-            {
-                o.ApplicationVersion = options.ApplicationVersion;
-                o.DeveloperMode = options.DeveloperMode;
-                o.EnableAdaptiveSampling = options.EnableAdaptiveSampling;
-                o.EnableAuthenticationTrackingJavaScript = options.EnableAuthenticationTrackingJavaScript;
-                o.EnableDebugLogger = options.EnableDebugLogger;
-                o.EnableQuickPulseMetricStream = options.EnableQuickPulseMetricStream;
-                o.EndpointAddress = options.EndpointAddress;
-                o.InstrumentationKey = options.InstrumentationKey;
-                o.EnableHeartbeat = options.EnableHeartbeat;
-                o.AddAutoCollectedMetricExtractor = options.AddAutoCollectedMetricExtractor;
-            });
+            services.Configure((ApplicationInsightsServiceOptions o) => options.CopyPropertiesTo(o));
             return services;
         }
 

--- a/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
@@ -86,19 +86,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ApplicationInsightsServiceOptions options)
         {
             services.AddApplicationInsightsTelemetryWorkerService();
-            services.Configure((ApplicationInsightsServiceOptions o) =>
-            {
-                o.ApplicationVersion = options.ApplicationVersion;
-                o.DeveloperMode = options.DeveloperMode;
-                o.EnableAdaptiveSampling = options.EnableAdaptiveSampling;
-                o.EnableAuthenticationTrackingJavaScript = options.EnableAuthenticationTrackingJavaScript;
-                o.EnableDebugLogger = options.EnableDebugLogger;
-                o.EnableQuickPulseMetricStream = options.EnableQuickPulseMetricStream;
-                o.EndpointAddress = options.EndpointAddress;
-                o.InstrumentationKey = options.InstrumentationKey;
-                o.EnableHeartbeat = options.EnableHeartbeat;
-                o.AddAutoCollectedMetricExtractor = options.AddAutoCollectedMetricExtractor;
-            });
+            services.Configure((ApplicationInsightsServiceOptions o) => options.CopyPropertiesTo(o));
             return services;
         }
 

--- a/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -465,44 +465,6 @@
         }
 #endif
 
-        private static void ConfigureAiServiceOption(IServiceCollection services, ApplicationInsightsServiceOptions options)
-        {
-            services.Configure((ApplicationInsightsServiceOptions o) =>
-            {
-                if (options.DeveloperMode != null)
-                {
-                    o.DeveloperMode = options.DeveloperMode;
-                }
-
-                if (!string.IsNullOrEmpty(options.EndpointAddress))
-                {
-                    o.EndpointAddress = options.EndpointAddress;
-                }
-
-                if (!string.IsNullOrEmpty(options.InstrumentationKey))
-                {
-                    o.InstrumentationKey = options.InstrumentationKey;
-                }
-
-                o.ApplicationVersion = options.ApplicationVersion;
-                o.EnableAdaptiveSampling = options.EnableAdaptiveSampling;
-                o.EnableDebugLogger = options.EnableDebugLogger;
-                o.EnableQuickPulseMetricStream = options.EnableQuickPulseMetricStream;
-                o.EnableHeartbeat = options.EnableHeartbeat;
-                o.AddAutoCollectedMetricExtractor = options.AddAutoCollectedMetricExtractor;
-                o.EnablePerformanceCounterCollectionModule = options.EnablePerformanceCounterCollectionModule;
-                o.EnableDependencyTrackingTelemetryModule = options.EnableDependencyTrackingTelemetryModule;                
-                o.EnableAppServicesHeartbeatTelemetryModule = options.EnableAppServicesHeartbeatTelemetryModule;
-                o.EnableAzureInstanceMetadataTelemetryModule = options.EnableAzureInstanceMetadataTelemetryModule;
-#if NETSTANDARD2_0
-                o.EnableEventCounterCollectionModule = options.EnableEventCounterCollectionModule;
-#endif 
-#if AI_ASPNETCORE_WEB
-                o.EnableAuthenticationTrackingJavaScript = options.EnableAuthenticationTrackingJavaScript;
-                o.EnableRequestTrackingTelemetryModule = options.EnableRequestTrackingTelemetryModule;
-#endif
-            });
-        }
 
         private static void AddApplicationInsightsLoggerProvider(IServiceCollection services)
         {

--- a/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
@@ -91,10 +91,23 @@
         public RequestCollectionOptions RequestCollectionOptions { get; }
 #endif
 
-
         /// <summary>
         /// Gets <see cref="DependencyCollectionOptions"/> that allow to manage <see cref="DependencyTrackingTelemetryModule"/>
         /// </summary>
         public DependencyCollectionOptions DependencyCollectionOptions { get; }
+
+        internal void CopyPropertiesTo(ApplicationInsightsServiceOptions target)
+        {
+            target.ApplicationVersion = this.ApplicationVersion;
+            target.DeveloperMode = this.DeveloperMode;
+            target.EnableAdaptiveSampling = this.EnableAdaptiveSampling;
+            target.EnableAuthenticationTrackingJavaScript = this.EnableAuthenticationTrackingJavaScript;
+            target.EnableDebugLogger = this.EnableDebugLogger;
+            target.EnableQuickPulseMetricStream = this.EnableQuickPulseMetricStream;
+            target.EndpointAddress = this.EndpointAddress;
+            target.InstrumentationKey = this.InstrumentationKey;
+            target.EnableHeartbeat = this.EnableHeartbeat;
+            target.AddAutoCollectedMetricExtractor = this.AddAutoCollectedMetricExtractor;
+        }
     }
 }

--- a/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
@@ -145,16 +145,38 @@
 
         internal void CopyPropertiesTo(ApplicationInsightsServiceOptions target)
         {
+            if (this.DeveloperMode != null)
+            {
+                target.DeveloperMode = this.DeveloperMode;
+            }
+
+            if (!string.IsNullOrEmpty(this.EndpointAddress))
+            {
+                target.EndpointAddress = this.EndpointAddress;
+            }
+
+            if (!string.IsNullOrEmpty(this.InstrumentationKey))
+            {
+                target.InstrumentationKey = this.InstrumentationKey;
+            }
+
             target.ApplicationVersion = this.ApplicationVersion;
-            target.DeveloperMode = this.DeveloperMode;
             target.EnableAdaptiveSampling = this.EnableAdaptiveSampling;
-            target.EnableAuthenticationTrackingJavaScript = this.EnableAuthenticationTrackingJavaScript;
             target.EnableDebugLogger = this.EnableDebugLogger;
             target.EnableQuickPulseMetricStream = this.EnableQuickPulseMetricStream;
-            target.EndpointAddress = this.EndpointAddress;
-            target.InstrumentationKey = this.InstrumentationKey;
             target.EnableHeartbeat = this.EnableHeartbeat;
             target.AddAutoCollectedMetricExtractor = this.AddAutoCollectedMetricExtractor;
+            target.EnablePerformanceCounterCollectionModule = this.EnablePerformanceCounterCollectionModule;
+            target.EnableDependencyTrackingTelemetryModule = this.EnableDependencyTrackingTelemetryModule;
+            target.EnableAppServicesHeartbeatTelemetryModule = this.EnableAppServicesHeartbeatTelemetryModule;
+            target.EnableAzureInstanceMetadataTelemetryModule = this.EnableAzureInstanceMetadataTelemetryModule;
+#if NETSTANDARD2_0
+            target.EnableEventCounterCollectionModule = this.EnableEventCounterCollectionModule;
+#endif
+#if AI_ASPNETCORE_WEB
+            target.EnableAuthenticationTrackingJavaScript = this.EnableAuthenticationTrackingJavaScript;
+            target.EnableRequestTrackingTelemetryModule = this.EnableRequestTrackingTelemetryModule;
+#endif
         }
     }
 }


### PR DESCRIPTION
I'm adding new properties to ApplicationInsightsServiceOptions to support ConnecitonStrings
I need to make sure I support all the use cases (I found one of the copies but didn't immediately find the second).
This POCO should be able to manage it's own copy properties.
This will also help future devs who add a new property to also add to this method.