### PR TITLE
fix fxcop warnings

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -655,7 +655,7 @@
             }
         }
 
-        private string GetNameFromRouteContext(IDictionary<string, object> routeValues)
+        private static string GetNameFromRouteContext(IDictionary<string, object> routeValues)
         {
             string name = null;
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -40,7 +40,7 @@
         private static readonly ActiveSubsciptionManager SubscriptionManager = new ActiveSubsciptionManager();
 
         /// <summary>
-        /// This class need to be aware of the AspNetCore major version. 
+        /// This class need to be aware of the AspNetCore major version.
         /// This will affect what DiagnosticSource events we receive.
         /// To support AspNetCore 1.0,2.0,3.0 we listen to both old and new events.
         /// If the running AspNetCore version is 2.0 or 3.0, both old and new events will be sent. In this case, we will ignore the old events.
@@ -99,7 +99,7 @@
             bool injectResponseHeaders,
             bool trackExceptions,
             bool enableW3CHeaders,
-            AspNetCoreMajorVersion aspNetCoreMajorVersion )
+            AspNetCoreMajorVersion aspNetCoreMajorVersion)
         {
             this.aspNetCoreMajorVersion = aspNetCoreMajorVersion;
             this.client = client ?? throw new ArgumentNullException(nameof(client));
@@ -197,9 +197,9 @@
                 // 2. Incoming Request-ID Headers. originalParentId will be request-id, but Activity ignores this for ID calculations.
                 //    If incoming ID is W3C compatible, ignore current Activity. Create new one with parent set to incoming W3C compatible rootid.
                 //    If incoming ID is not W3C compatible, we can use Activity as such, but need to store originalParentID in custom property 'legacyRootId'
-                // 3. Incoming TraceParent header. 
+                // 3. Incoming TraceParent header.
                 //    3a - 2.XX Need to ignore current Activity, and create new from incoming W3C TraceParent header.
-                //    3b - 3.XX Use Activity as such because 3.XX is W3C Aware. 
+                //    3b - 3.XX Use Activity as such because 3.XX is W3C Aware.
 
                 // Another 3 possibilities when TelemetryConfiguration.EnableW3CCorrelation = false
                 // 1. No incoming headers. originalParentId will be null. Simply use the Activity as such.
@@ -235,11 +235,12 @@
                     AspNetCoreEventSource.Instance.HostingListenerInformational(this.aspNetCoreMajorVersion, "Ignoring original Activity from Hosting to create new one using traceparent header retrieved by sdk.");
 
                     // read and populate tracestate
-                    ReadTraceState(httpContext.Request.Headers, newActivity);                    
+                    ReadTraceState(httpContext.Request.Headers, newActivity);
                 }
                 else if (this.aspNetCoreMajorVersion == AspNetCoreMajorVersion.Three && headers.ContainsKey(W3CConstants.TraceParentHeader))
                 {
                     AspNetCoreEventSource.Instance.HostingListenerInformational(this.aspNetCoreMajorVersion, "Incoming request has traceparent. Using Activity created from Hosting.");
+                    
                     // scenario #3b Use Activity created by Hosting layer when W3C Headers Present.
                     // but ignore parent if user disabled w3c.
                     if (currentActivity.IdFormat != ActivityIdFormat.W3C)
@@ -270,7 +271,7 @@
                             AspNetCoreEventSource.Instance.HostingListenerInformational(this.aspNetCoreMajorVersion, "Incoming Request-ID is not W3C Compatible, and hence will be ignored for ID generation, but stored in custom property legacy_rootID.");
                         }
                     }
-                }                
+                }
 
                 if (newActivity != null)
                 {
@@ -330,7 +331,7 @@
                     activity.SetParentId(parentTraceParent);
                     originalParentId = parentTraceParent;
 
-                    ReadTraceState(requestHeaders, activity);                    
+                    ReadTraceState(requestHeaders, activity);
                 }
 
                 // Request-Id
@@ -353,7 +354,7 @@
                     else
                     {
                         activity.SetParentId(originalParentId);
-                    }                    
+                    }
                 }
 
                 // no headers
@@ -541,7 +542,7 @@
         {
         }
 
-        private string GetParentId(Activity activity, string originalParentId, string operationId)
+        private static string GetParentId(Activity activity, string originalParentId, string operationId)
         {
             if (activity.IdFormat == ActivityIdFormat.W3C && activity.ParentSpanId != default)
             {
@@ -745,7 +746,7 @@
                 && this.configuration != null
                 && !string.IsNullOrEmpty(requestTelemetry.Context.Operation.Id)
                 && SamplingScoreGenerator.GetSamplingScore(requestTelemetry.Context.Operation.Id) >= this.configuration.GetLastObservedSamplingPercentage(requestTelemetry.ItemTypeFlag))
-            {                
+            {
                 requestTelemetry.ProactiveSamplingDecision = SamplingDecision.SampledOut;
                 AspNetCoreEventSource.Instance.TelemetryItemWasSampledOutAtHead(requestTelemetry.Context.Operation.Id);
             }
@@ -826,7 +827,8 @@
 
                     HttpHeadersUtilities.SetRequestContextKeyValue(
                         responseHeaders,
-                        RequestResponseHeaders.RequestContextTargetKey, this.lastAppIdUsed);
+                        RequestResponseHeaders.RequestContextTargetKey,
+                        this.lastAppIdUsed);
                 }
             }
         }
@@ -878,8 +880,6 @@
                 }
 
                 this.client.TrackRequest(telemetry);
-
-                
 
                 // Stop what we started.
                 var activity = Activity.Current;

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -153,8 +153,7 @@
 
             if (telemetry != null && string.IsNullOrEmpty(telemetry.Name))
             {
-                string name = this.GetNameFromRouteContext(routeValues);
-
+                string name = GetNameFromRouteContext(routeValues);
                 if (!string.IsNullOrEmpty(name))
                 {
                     name = httpContext.Request.Method + " " + name;
@@ -240,7 +239,7 @@
                 else if (this.aspNetCoreMajorVersion == AspNetCoreMajorVersion.Three && headers.ContainsKey(W3CConstants.TraceParentHeader))
                 {
                     AspNetCoreEventSource.Instance.HostingListenerInformational(this.aspNetCoreMajorVersion, "Incoming request has traceparent. Using Activity created from Hosting.");
-                    
+
                     // scenario #3b Use Activity created by Hosting layer when W3C Headers Present.
                     // but ignore parent if user disabled w3c.
                     if (currentActivity.IdFormat != ActivityIdFormat.W3C)

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/IApplicationInsightDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/IApplicationInsightDiagnosticListener.cs
@@ -4,17 +4,17 @@
     using System.Collections.Generic;
 
     /// <summary>
-    /// Base diagnostic listener type for Application Insight
+    /// Base diagnostic listener type for Application Insight.
     /// </summary>
     internal interface IApplicationInsightDiagnosticListener : IDisposable, IObserver<KeyValuePair<string, object>>
     {
         /// <summary>
-        /// Gets a value indicating which listener this instance should be subscribed to
+        /// Gets a value indicating which listener this instance should be subscribed to.
         /// </summary>
         string ListenerName { get; }
 
         /// <summary>
-        /// Notifies listener that it is subscribed to DiagnosticSource
+        /// Notifies listener that it is subscribed to DiagnosticSource.
         /// </summary>
         void OnSubscribe();
     }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs
@@ -83,7 +83,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
         {
         }
 
-        private string GetNameFromRouteContext(IDictionary<string, object> routeValues)
+        private static string GetNameFromRouteContext(IDictionary<string, object> routeValues)
         {
             string name = null;
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs
@@ -30,8 +30,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
 
             if (telemetry != null && string.IsNullOrEmpty(telemetry.Name))
             {
-                string name = this.GetNameFromRouteContext(routeValues);
-
+                string name = GetNameFromRouteContext(routeValues);
                 if (!string.IsNullOrEmpty(name))
                 {
                     name = httpContext.Request.Method + " " + name;

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/PropertyFetcher.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/PropertyFetcher.cs
@@ -4,7 +4,7 @@
     using System.Reflection;
 
     // see https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
-    
+
     /// <summary>
     /// Efficient implementation of fetching properties of anonymous types with reflection.
     /// </summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/RequestResponseHeaders.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/RequestResponseHeaders.cs
@@ -30,13 +30,14 @@
         /// </summary>
         public const string CorrelationContextHeader = "Correlation-Context";
 
-        //
-        // Summary:
-        //     W3C traceparent header name.
+        /// <summary>
+        /// W3C traceparent header name.
+        /// </summary>
         public const string TraceParentHeader = "traceparent";
-        //
-        // Summary:
-        //     W3C tracestate header name.
+
+        /// <summary>
+        /// W3C tracestate header name.
+        /// </summary>
         public const string TraceStateHeader = "tracestate";
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
@@ -187,7 +187,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         {
             this.WriteEvent(17, errorMessage, this.ApplicationName);
         }
-        
+
         /// <summary>
         /// Logs an event when a telemetry item is sampled out at head.
         /// </summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -149,10 +149,10 @@
 
                     services.ConfigureTelemetryModule<RequestTrackingTelemetryModule>((module, options) =>
                     {
-                        if(options.EnableRequestTrackingTelemetryModule)
+                        if (options.EnableRequestTrackingTelemetryModule)
                         {
                             module.CollectionOptions = options.RequestCollectionOptions;
-                        }                        
+                        }
                     });
 
                     AddCommonTelemetryModules(services);
@@ -174,8 +174,9 @@
                     // that requires IOptions infrastructure to run and initialize
                     services.AddSingleton<IStartupFilter, ApplicationInsightsStartupFilter>();
                     services.AddSingleton<IJavaScriptSnippet, JavaScriptSnippet>();
+                    
                     // Add 'JavaScriptSnippet' "Service" for backwards compatibility. To remove in favour of 'IJavaScriptSnippet'.
-                    services.AddSingleton<JavaScriptSnippet>(); 
+                    services.AddSingleton<JavaScriptSnippet>();
 
                     // NetStandard2.0 has a package reference to Microsoft.Extensions.Logging.ApplicationInsights, and
                     // enables ApplicationInsightsLoggerProvider by default.

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -174,7 +174,7 @@
                     // that requires IOptions infrastructure to run and initialize
                     services.AddSingleton<IStartupFilter, ApplicationInsightsStartupFilter>();
                     services.AddSingleton<IJavaScriptSnippet, JavaScriptSnippet>();
-                    
+
                     // Add 'JavaScriptSnippet' "Service" for backwards compatibility. To remove in favour of 'IJavaScriptSnippet'.
                     services.AddSingleton<JavaScriptSnippet>();
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsWebHostBuilderExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsWebHostBuilderExtensions.cs
@@ -1,10 +1,8 @@
 ﻿namespace Microsoft.AspNetCore.Hosting
 {
-    using Microsoft.ApplicationInsights.AspNetCore.Extensions;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.DependencyInjection.Extensions;
-    using Microsoft.Extensions.Options;
     using System;
+
+    using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
     /// Extension methods for <see cref="IWebHostBuilder"/> that allow adding Application Insights services to application.

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DefaultApplicationInsightsServiceConfigureOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DefaultApplicationInsightsServiceConfigureOptions.cs
@@ -17,9 +17,9 @@
         private readonly IHostingEnvironment hostingEnvironment;
 
         /// <summary>
-        /// Creates a new instance of <see cref="DefaultApplicationInsightsServiceConfigureOptions"/>
+        /// Initializes a new instance of the <see cref="DefaultApplicationInsightsServiceConfigureOptions"/> class.
         /// </summary>
-        /// <param name="hostingEnvironment"><see cref="IHostingEnvironment"/> to use for retreiving ContentRootPath</param>
+        /// <param name="hostingEnvironment"><see cref="IHostingEnvironment"/> to use for retreiving ContentRootPath.</param>
         public DefaultApplicationInsightsServiceConfigureOptions(IHostingEnvironment hostingEnvironment)
         {
             this.hostingEnvironment = hostingEnvironment;
@@ -31,7 +31,7 @@
             var configBuilder = new ConfigurationBuilder()
                 .SetBasePath(this.hostingEnvironment.ContentRootPath ?? Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", true)
-                .AddJsonFile(string.Format(CultureInfo.InvariantCulture, "appsettings.{0}.json", hostingEnvironment.EnvironmentName), true)
+                .AddJsonFile(string.Format(CultureInfo.InvariantCulture, "appsettings.{0}.json", this.hostingEnvironment.EnvironmentName), true)
                 .AddEnvironmentVariables();
             ApplicationInsightsExtensions.AddTelemetryConfiguration(configBuilder.Build(), options);
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/HttpRequestExtensions.cs
@@ -4,7 +4,7 @@
     using Microsoft.AspNetCore.Http;
 
     /// <summary>
-    /// Set of extension methods for Microsoft.AspNetCore.Http.HttpRequest
+    /// Set of extension methods for Microsoft.AspNetCore.Http.HttpRequest.
     /// </summary>
     public static class HttpRequestExtensions
     {
@@ -15,7 +15,7 @@
         /// <summary>
         /// Gets http request Uri from request object.
         /// </summary>
-        /// <param name="request">The <see cref="HttpRequest"/></param>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
         /// <returns>A New Uri object representing request Uri.</returns>
         public static Uri GetUri(this HttpRequest request)
         {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/RequestCollectionOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/RequestCollectionOptions.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace Microsoft.ApplicationInsights.AspNetCore.Extensions
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Extensions
 {
+    using System;
+
     /// <summary>
     /// Request collection options define the custom behavior or non-default features of request collection.
     /// </summary>
@@ -40,7 +40,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensions
         /// <summary>
         /// Gets or sets a value indicating whether W3C distributed tracing standard is enabled.
         /// </summary>
-        [Obsolete("This flag is obsolete and noop. Use System.Diagnostics.Activity.DefaultIdFormat (along with ForceDefaultIdFormat) flags instead.")] 
+        [Obsolete("This flag is obsolete and noop. Use System.Diagnostics.Activity.DefaultIdFormat (along with ForceDefaultIdFormat) flags instead.")]
         public bool EnableW3CDistributedTracing { get; set; }
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ApplicationInsightsStartupFilter.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ApplicationInsightsStartupFilter.cs
@@ -10,17 +10,17 @@
     using Microsoft.Extensions.Logging;
 
     /// <summary>
-    /// <see cref="IStartupFilter"/> implementation that initialized ApplicationInsights services on application startup
+    /// <see cref="IStartupFilter"/> implementation that initialized ApplicationInsights services on application startup.
     /// </summary>
     internal class ApplicationInsightsStartupFilter : IStartupFilter
     {
         private readonly ILogger<ApplicationInsightsStartupFilter> logger;
-        
+
         public ApplicationInsightsStartupFilter(ILogger<ApplicationInsightsStartupFilter> logger)
         {
             this.logger = logger;
         }
-        
+
         /// <inheritdoc/>
         public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
         {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/AspNetCoreMajorVersion.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/AspNetCoreMajorVersion.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Microsoft.ApplicationInsights.AspNetCore.Implementation
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Implementation
 {
-    internal enum AspNetCoreMajorVersion { One, Two, Three };
+    internal enum AspNetCoreMajorVersion 
+    {
+        One,
+        Two,
+        Three
+    };
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/AspNetCoreMajorVersion.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/AspNetCoreMajorVersion.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNetCore.Implementation
 {
-    internal enum AspNetCoreMajorVersion 
+    internal enum AspNetCoreMajorVersion
     {
         One,
         Two,

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/AspNetCoreMajorVersion.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/AspNetCoreMajorVersion.cs
@@ -4,6 +4,6 @@
     {
         One,
         Two,
-        Three
+        Three,
     };
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ProviderAliasAttribute.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/ProviderAliasAttribute.cs
@@ -3,7 +3,7 @@ namespace Microsoft.Extensions.Logging
     using System;
 
     /// <summary>
-    /// Controls logger provider alias used for configuration
+    /// Controls logger provider alias used for configuration.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
     internal class ProviderAliasAttribute : Attribute
@@ -11,13 +11,10 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         /// Initializes a new instance of the <see cref="ProviderAliasAttribute" /> class.
         /// </summary>
-        public ProviderAliasAttribute(string alias)
-        {
-            Alias = alias;
-        }
+        public ProviderAliasAttribute(string alias) => this.Alias = alias;
 
         /// <summary>
-        /// Gets an alias that can be used insted full type name during configuration.
+        /// Gets an alias that can be used instead of full type name during configuration.
         /// </summary>
         public string Alias { get; }
     }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/TelemetryConfigurationOptions.cs
@@ -10,7 +10,7 @@
     /// </summary>
     internal class TelemetryConfigurationOptions : IOptions<TelemetryConfiguration>
     {
-        private static readonly object lockObject = new object();
+        private static readonly object LockObject = new object();
 
         public TelemetryConfigurationOptions(IEnumerable<IConfigureOptions<TelemetryConfiguration>> configureOptions)
         {
@@ -22,7 +22,7 @@
                 c.Configure(this.Value);
             }
 
-            lock (lockObject)
+            lock (LockObject)
             {
                 // workaround for Microsoft/ApplicationInsights-dotnet#613
                 // as we expect some customers to use TelemetryConfiguration.Active together with dependency injection

--- a/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
@@ -19,11 +19,11 @@
         /// <summary>JavaScript authenticated user tracking snippet.</summary>
         private static readonly string AuthSnippet = Resources.JavaScriptAuthSnippet;
 
-        /// <summary>Configuration instance.</summary>
-        private TelemetryConfiguration telemetryConfiguration;
-
         /// <summary> Http context accessor.</summary>
         private readonly IHttpContextAccessor httpContextAccessor;
+
+        /// <summary>Configuration instance.</summary>
+        private TelemetryConfiguration telemetryConfiguration;
 
         /// <summary> Weather to print authenticated user tracking snippet.</summary>
         private bool enableAuthSnippet;

--- a/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/JavaScriptSnippet.cs
@@ -31,7 +31,7 @@
         private JavaScriptEncoder encoder;
 
         /// <summary>
-        /// Initializes a new instance of the JavaScriptSnippet class.
+        /// Initializes a new instance of the <see cref="JavaScriptSnippet"/> class.
         /// </summary>
         /// <param name="telemetryConfiguration">The configuration instance to use.</param>
         /// <param name="serviceOptions">Service options instance to use.</param>
@@ -62,13 +62,14 @@
                 {
                     string additionalJS = string.Empty;
                     IIdentity identity = this.httpContextAccessor?.HttpContext?.User?.Identity;
-                    if (enableAuthSnippet &&
+                    if (this.enableAuthSnippet &&
                         identity != null &&
                         identity.IsAuthenticated)
                     {
-                        string escapedUserName = encoder.Encode(identity.Name);
+                        string escapedUserName = this.encoder.Encode(identity.Name);
                         additionalJS = string.Format(CultureInfo.InvariantCulture, AuthSnippet, escapedUserName);
                     }
+
                     return string.Format(CultureInfo.InvariantCulture, Snippet, this.telemetryConfiguration.InstrumentationKey, additionalJS);
                 }
                 else

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLogger.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLogger.cs
@@ -29,7 +29,7 @@
         private readonly string sdkVersion = SdkVersionUtils.GetVersion(VersionPrefix);
 
         /// <summary>
-        /// Creates a new instance of <see cref="ApplicationInsightsLogger"/>.
+        /// Initializes a new instance of the <see cref="ApplicationInsightsLogger"/> class.
         /// </summary>
         public ApplicationInsightsLogger(string name, TelemetryClient telemetryClient, Func<string, LogLevel, bool> filter, ApplicationInsightsLoggerOptions options)
         {
@@ -48,7 +48,7 @@
         /// <inheritdoc />
         public bool IsEnabled(LogLevel logLevel)
         {
-            return this.filter != null && this.telemetryClient != null && this.filter(categoryName, logLevel) && this.telemetryClient.IsEnabled();
+            return this.filter != null && this.telemetryClient != null && this.filter(this.categoryName, logLevel) && this.telemetryClient.IsEnabled();
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerEvents.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerEvents.cs
@@ -3,7 +3,7 @@
     using System;
 
     /// <summary>
-    /// Class to provide ApplicationInsights logger events
+    /// Class to provide ApplicationInsights logger events.
     /// </summary>
     internal class ApplicationInsightsLoggerEvents
     {
@@ -17,7 +17,7 @@
         /// </summary>
         public void OnLoggerAdded()
         {
-            LoggerAdded?.Invoke();
+            this.LoggerAdded?.Invoke();
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerFactoryExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerFactoryExtensions.cs
@@ -15,7 +15,7 @@
         /// <summary>
         /// Adds an ApplicationInsights logger that is enabled for <see cref="LogLevel.Warning"/> or higher.
         /// </summary>
-        /// <param name="factory"></param>
+        /// <param name="factory">Used to configure the logging system and create instances of ILogger from the registered ILoggerProviders.</param>
         /// <param name="serviceProvider">The instance of <see cref="IServiceProvider"/> to use for service resolution.</param>
         [Obsolete("ApplicationInsightsLoggerProvider is now enabled by default when enabling ApplicationInsights monitoring using UseApplicationInsights extension method on IWebHostBuilder or AddApplicationInsightsTelemetry extension method on IServiceCollection. From 2.7.0-beta3 onwards, calling this method will result in double logging and filters applied will not get applied. If interested in using just logging provider, then please use Microsoft.Extensions.Logging.ApplicationInsightsLoggingBuilderExtensions.AddApplicationInsights from Microsoft.Extensions.Logging.ApplicationInsights package. Read more https://aka.ms/ApplicationInsightsILoggerFaq")]
         public static ILoggerFactory AddApplicationInsights(this ILoggerFactory factory, IServiceProvider serviceProvider)
@@ -26,9 +26,9 @@
         /// <summary>
         /// Adds an ApplicationInsights logger that is enabled for <see cref="LogLevel"/>s of minLevel or higher.
         /// </summary>
-        /// <param name="factory"></param>
+        /// <param name="factory">Used to configure the logging system and create instances of ILogger from the registered ILoggerProviders.</param>
         /// <param name="serviceProvider">The instance of <see cref="IServiceProvider"/> to use for service resolution.</param>
-        /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
+        /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged.</param>
         [Obsolete("ApplicationInsightsLoggerProvider is now enabled by default when enabling ApplicationInsights monitoring using UseApplicationInsights extension method on IWebHostBuilder or AddApplicationInsightsTelemetry extension method on IServiceCollection. From 2.7.0-beta3 onwards, calling this method will result in double logging and filters applied will not get applied. If interested in using just logging provider, then please use Microsoft.Extensions.Logging.ApplicationInsightsLoggingBuilderExtensions.AddApplicationInsights from Microsoft.Extensions.Logging.ApplicationInsights package. Read more https://aka.ms/ApplicationInsightsILoggerFaq")]
         public static ILoggerFactory AddApplicationInsights(
             this ILoggerFactory factory,
@@ -42,7 +42,7 @@
         /// <summary>
         /// Adds an ApplicationInsights logger that is enabled as defined by the filter function.
         /// </summary>
-        /// <param name="factory"></param>
+        /// <param name="factory">Used to configure the logging system and create instances of ILogger from the registered ILoggerProviders.</param>
         /// <param name="serviceProvider">The instance of <see cref="IServiceProvider"/> to use for service resolution.</param>
         /// <param name="filter"></param>
         [Obsolete("ApplicationInsightsLoggerProvider is now enabled by default when enabling ApplicationInsights monitoring using UseApplicationInsights extension method on IWebHostBuilder or AddApplicationInsightsTelemetry extension method on IServiceCollection. From 2.7.0-beta3 onwards, calling this method will result in double logging and filters applied will not get applied. If interested in using just logging provider, then please use Microsoft.Extensions.Logging.ApplicationInsightsLoggingBuilderExtensions.AddApplicationInsights from Microsoft.Extensions.Logging.ApplicationInsights package. Read more https://aka.ms/ApplicationInsightsILoggerFaq")]
@@ -57,9 +57,9 @@
         /// <summary>
         /// Adds an ApplicationInsights logger that is enabled as defined by the filter function.
         /// </summary>
-        /// <param name="factory"></param>
+        /// <param name="factory">Used to configure the logging system and create instances of ILogger from the registered ILoggerProviders.</param>
         /// <param name="serviceProvider">The instance of <see cref="IServiceProvider"/> to use for service resolution.</param>
-        /// <param name="filter">Filter action</param>
+        /// <param name="filter">Filter action.</param>
         /// <param name="loggerAddedCallback">The callback that gets executed when another ApplicationInsights logger is added.</param>
         [Obsolete("ApplicationInsightsLoggerProvider is now enabled by default when enabling ApplicationInsights monitoring using UseApplicationInsights extension method on IWebHostBuilder or AddApplicationInsightsTelemetry extension method on IServiceCollection. From 2.7.0-beta3 onwards, calling this method will result in double logging and filters applied will not get applied. If interested in using just logging provider, then please use Microsoft.Extensions.Logging.ApplicationInsightsLoggingBuilderExtensions.AddApplicationInsights from Microsoft.Extensions.Logging.ApplicationInsights package. Read more https://aka.ms/ApplicationInsightsILoggerFaq")]
         public static ILoggerFactory AddApplicationInsights(

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerOptions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerOptions.cs
@@ -16,17 +16,16 @@
         /// </summary>
         public ApplicationInsightsLoggerOptions()
         {
-            TrackExceptionsAsExceptionTelemetry = true;
+            this.TrackExceptionsAsExceptionTelemetry = true;
         }
 
         /// <summary>
-        /// Gets or sets a value whether to track exceptions as <see cref="ExceptionTelemetry"/>.
+        /// Gets or sets a value indicating whether to track exceptions as <see cref="ExceptionTelemetry"/>.
         /// </summary>
-        public bool TrackExceptionsAsExceptionTelemetry
-        { get; set; }
+        public bool TrackExceptionsAsExceptionTelemetry { get; set; }
 
         /// <summary>
-        /// Gets or sets value indicating, whether EventId and EventName properties should be included in telemetry.
+        /// Gets or sets a value indicating whether EventId and EventName properties should be included in telemetry.
         /// </summary>
         public bool IncludeEventId { get; set; }
     }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerProvider.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerProvider.cs
@@ -5,7 +5,7 @@
     using Microsoft.Extensions.Options;
 
     /// <summary>
-    /// <see cref="ILoggerProvider"/> implementation that creates returns instances of <see cref="ApplicationInsightsLogger"/>
+    /// <see cref="ILoggerProvider"/> implementation that creates returns instances of <see cref="ApplicationInsightsLogger"/>.
     /// </summary>
 #if !NETSTANDARD2_0
     // For NETSTANDARD2.0 We take dependency on Microsoft.Extensions.Logging.ApplicationInsights which has ApplicationInsightsProvider having the same ProviderAlias and don't want to clash with this ProviderAlias.
@@ -30,7 +30,7 @@
         /// <inheritdoc />
         public ILogger CreateLogger(string categoryName)
         {
-            return new ApplicationInsightsLogger(categoryName, this.telemetryClient, filter, options);
+            return new ApplicationInsightsLogger(categoryName, this.telemetryClient, this.filter, this.options);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -34,6 +34,10 @@
     <DebugSymbols>true</DebugSymbols>    
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <NoWarn>1701;1702</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(Configuration)' == 'Release' And $(OS) == 'Windows_NT'">
     <!--Analyzers-->
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0">

--- a/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestTrackingTelemetryModule"/> class.
         /// </summary>
-        /// <param name="applicationIdProvider">Provider to resolve Application Id</param>
+        /// <param name="applicationIdProvider">Provider to resolve Application Id.</param>
         public RequestTrackingTelemetryModule(IApplicationIdProvider applicationIdProvider)
         {
             this.applicationIdProvider = applicationIdProvider;
@@ -88,7 +88,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore
                                 else
                                 {
                                     aspNetCoreMajorVersion = AspNetCoreMajorVersion.Three;
-                                }                                
+                                }
                             }
                             catch (Exception e)
                             {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationNameTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationNameTelemetryInitializer.cs
@@ -13,7 +13,8 @@
         /// Initializes a new instance of the <see cref="OperationNameTelemetryInitializer" /> class.
         /// </summary>
         /// <param name="httpContextAccessor">Accessor to provide HttpContext corresponding to telemetry items.</param>
-        public OperationNameTelemetryInitializer(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
+        public OperationNameTelemetryInitializer(IHttpContextAccessor httpContextAccessor) 
+            : base(httpContextAccessor)
         {
         }
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationNameTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/OperationNameTelemetryInitializer.cs
@@ -13,7 +13,7 @@
         /// Initializes a new instance of the <see cref="OperationNameTelemetryInitializer" /> class.
         /// </summary>
         /// <param name="httpContextAccessor">Accessor to provide HttpContext corresponding to telemetry items.</param>
-        public OperationNameTelemetryInitializer(IHttpContextAccessor httpContextAccessor) 
+        public OperationNameTelemetryInitializer(IHttpContextAccessor httpContextAccessor)
             : base(httpContextAccessor)
         {
         }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/SyntheticTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/SyntheticTelemetryInitializer.cs
@@ -5,7 +5,7 @@
     using Microsoft.AspNetCore.Http;
 
     /// <summary>
-    /// This will allow to mark synthetic traffic from availability tests
+    /// This will allow to mark synthetic traffic from availability tests.
     /// </summary>
     public class SyntheticTelemetryInitializer : TelemetryInitializerBase
     {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/TelemetryInitializerBase.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/TelemetryInitializerBase.cs
@@ -9,7 +9,7 @@
     using Microsoft.AspNetCore.Http;
 
     /// <summary>
-    /// Base class for Telemetry Initializers. Provides access to HttpContext and RequestTelemetry
+    /// Base class for Telemetry Initializers. Provides access to HttpContext and RequestTelemetry.
     /// </summary>
     public abstract class TelemetryInitializerBase : ITelemetryInitializer
     {

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/WebUserTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/WebUserTelemetryInitializer.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers
 {
-    using Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.AspNetCore.Http;

--- a/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
@@ -1,28 +1,14 @@
-﻿using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers;
-using Microsoft.ApplicationInsights.WorkerService;
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.DependencyCollector;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Extensibility.EventCounterCollector;
-using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
-using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
-using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
-using Microsoft.ApplicationInsights.WindowsServer;
-using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-using Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing;
-
-namespace Microsoft.Extensions.DependencyInjection
+﻿namespace Microsoft.Extensions.DependencyInjection
 {
+    using System;
+
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.WorkerService;
+    using Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Options;
+
     /// <summary>
     /// Extension methods for <see cref="IServiceCollection"/> that allow adding Application Insights services to application.
     /// </summary>

--- a/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
@@ -103,12 +103,11 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 if (!IsApplicationInsightsAdded(services))
                 {
-                    AddCommonInitializers(services);                    
+                    AddCommonInitializers(services);
                     AddCommonTelemetryModules(services);
                     AddTelemetryChannel(services);
 
                     ConfigureEventCounterModuleWithSystemCounters(services);
-
 
                     services
                         .TryAddSingleton<IConfigureOptions<ApplicationInsightsServiceOptions>,

--- a/src/Microsoft.ApplicationInsights.WorkerService/DefaultApplicationInsightsServiceConfigureOptions.cs
+++ b/src/Microsoft.ApplicationInsights.WorkerService/DefaultApplicationInsightsServiceConfigureOptions.cs
@@ -8,16 +8,16 @@
     using Microsoft.Extensions.Options;
 
     /// <summary>
-    /// <see cref="IConfigureOptions&lt;ApplicationInsightsServiceOptions&gt;"/> implementation that reads options from provided IConfiguration    
+    /// <see cref="IConfigureOptions&lt;ApplicationInsightsServiceOptions&gt;"/> implementation that reads options from provided IConfiguration.
     /// </summary>
     internal class DefaultApplicationInsightsServiceConfigureOptions : IConfigureOptions<ApplicationInsightsServiceOptions>
     {
         private readonly IConfiguration configuration;
 
         /// <summary>
-        /// Creates a new instance of <see cref="DefaultApplicationInsightsServiceConfigureOptions"/>
+        /// Initializes a new instance of the <see cref="DefaultApplicationInsightsServiceConfigureOptions"/> class.
         /// </summary>
-        /// <param name="configuration"><see cref="IConfiguration"/> from which configuraion for ApplicationInsights can be retrieved.</param>
+        /// <param name="configuration"><see cref="IConfiguration"/> from which configuration for ApplicationInsights can be retrieved.</param>
         public DefaultApplicationInsightsServiceConfigureOptions(IConfiguration configuration = null)
         {
             this.configuration = configuration;
@@ -26,9 +26,9 @@
         /// <inheritdoc />
         public void Configure(ApplicationInsightsServiceOptions options)
         {
-            if (configuration != null)
+            if (this.configuration != null)
             {
-                ApplicationInsightsExtensions.AddTelemetryConfiguration(configuration, options);
+                ApplicationInsightsExtensions.AddTelemetryConfiguration(this.configuration, options);
             }
 
             if (Debugger.IsAttached)

--- a/src/Microsoft.ApplicationInsights.WorkerService/Implementation/TelemetryConfigurationOptions.cs
+++ b/src/Microsoft.ApplicationInsights.WorkerService/Implementation/TelemetryConfigurationOptions.cs
@@ -12,6 +12,10 @@
     {
         private static readonly object lockObject = new object();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TelemetryConfigurationOptions"/> class.
+        /// </summary>
+        /// <param name="configureOptions"></param>
         public TelemetryConfigurationOptions(IEnumerable<IConfigureOptions<TelemetryConfiguration>> configureOptions)
         {
             this.Value = TelemetryConfiguration.CreateDefault();

--- a/src/Microsoft.ApplicationInsights.WorkerService/Implementation/Tracing/WorkerServiceEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.WorkerService/Implementation/Tracing/WorkerServiceEventSource.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         /// <summary>
         /// Logs informational message.
         /// </summary>
-        /// <param name="message">Message</param>
+        /// <param name="message">Message.</param>
         /// <param name="appDomainName">An ignored placeholder to make EventSource happy.</param>
         [Event(1, Message = "Message : {0}", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
         public void LogInformational(string message, string appDomainName = "Incorrect")
@@ -65,7 +65,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         /// <summary>
         /// Logs warning message.
         /// </summary>
-        /// <param name="message">Message</param>
+        /// <param name="message">Message.</param>
         /// <param name="appDomainName">An ignored placeholder to make EventSource happy.</param>
         [Event(2, Message = "Message : {0}", Level = EventLevel.Warning)]
         public void LogWarning(string message, string appDomainName = "Incorrect")
@@ -76,9 +76,9 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         /// <summary>
         /// Logs error message.
         /// </summary>
-        /// <param name="message">Message</param>
+        /// <param name="message">Message.</param>
         /// <param name="appDomainName">An ignored placeholder to make EventSource happy.</param>
-        [Event(3, Message = "An error has occured which may prevent application insights from functioning. Error message: '{0}'", Level = EventLevel.Error)]
+        [Event(3, Message = "An error has occurred which may prevent application insights from functioning. Error message: '{0}'", Level = EventLevel.Error)]
         public void LogError(string message, string appDomainName = "Incorrect")
         {
             this.WriteEvent(3, message, this.ApplicationName);
@@ -96,11 +96,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         /// <summary>
         /// Logs an event when TelemetryConfiguration configure has failed.
         /// </summary>
-        [Event(
-           5,
-            Keywords = Keywords.Diagnostics,
-            Message = "An error has occured while setting up TelemetryConfiguration. Error message: '{0}' ",
-            Level = EventLevel.Error)]
+        [Event(5, Keywords = Keywords.Diagnostics, Message = "An error has occurred while setting up TelemetryConfiguration. Error message: '{0}' ", Level = EventLevel.Error)]
         public void TelemetryConfigurationSetupFailure(string errorMessage, string appDomainName = "Incorrect")
         {
             this.WriteEvent(5, errorMessage, this.ApplicationName);
@@ -109,7 +105,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         /// <summary>
         /// Keywords for the AspNetEventSource.
         /// </summary>
-        public sealed class Keywords
+        public static class Keywords
         {
             /// <summary>
             /// Keyword for errors that trace at Verbose level.

--- a/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+
     using Microsoft.ApplicationInsights;
 #if AI_ASPNETCORE_WEB
     using Microsoft.ApplicationInsights.AspNetCore;
@@ -32,6 +33,7 @@
 #endif
     using Microsoft.Extensions.Options;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
+
     using Shared.Implementation;
 
     /// <summary>
@@ -49,7 +51,6 @@
         private const string EndpointAddressForWebSites = "APPINSIGHTS_ENDPOINTADDRESS";
         private const string EventSourceNameForSystemRuntime = "System.Runtime";
         private const string EventSourceNameForAspNetCoreHosting = "Microsoft.AspNetCore.Hosting";
-
 
         /// <summary>
         /// Adds an Application Insights Telemetry Processor into a service collection via a <see cref="ITelemetryProcessorFactory"/>.
@@ -76,8 +77,7 @@
         /// </returns>
         /// <exception cref="ArgumentNullException">The <paramref name="telemetryProcessorType"/> argument is null.</exception>
         /// <exception cref="ArgumentException">The <paramref name="telemetryProcessorType"/> type does not implement <see cref="ITelemetryProcessor"/>.</exception>
-        public static IServiceCollection AddApplicationInsightsTelemetryProcessor(this IServiceCollection services,
-            Type telemetryProcessorType)
+        public static IServiceCollection AddApplicationInsightsTelemetryProcessor(this IServiceCollection services, Type telemetryProcessorType)
         {
             if (telemetryProcessorType == null)
             {
@@ -110,7 +110,8 @@
                 throw new ArgumentNullException(nameof(configModule));
             }
 
-            return services.AddSingleton(typeof(ITelemetryModuleConfigurator),
+            return services.AddSingleton(
+                typeof(ITelemetryModuleConfigurator),
                 new TelemetryModuleConfigurator((config, options) => configModule((T)config), typeof(T)));
         }
 
@@ -132,7 +133,8 @@
                 throw new ArgumentNullException(nameof(configModule));
             }
 
-            return services.AddSingleton(typeof(ITelemetryModuleConfigurator),
+            return services.AddSingleton(
+                typeof(ITelemetryModuleConfigurator),
                 new TelemetryModuleConfigurator((config, options) => configModule((T)config, options), typeof(T)));
         }
 
@@ -167,16 +169,13 @@
 
             if (instrumentationKey != null)
             {
-                telemetryConfigValues.Add(new KeyValuePair<string, string>(InstrumentationKeyForWebSites,
-                    instrumentationKey));
+                telemetryConfigValues.Add(new KeyValuePair<string, string>(InstrumentationKeyForWebSites, instrumentationKey));
                 wasAnythingSet = true;
             }
 
             if (endpointAddress != null)
             {
-                telemetryConfigValues.Add(new KeyValuePair<string, string>(
-                    EndpointAddressForWebSites,
-                    endpointAddress));
+                telemetryConfigValues.Add(new KeyValuePair<string, string>(EndpointAddressForWebSites, endpointAddress));
                 wasAnythingSet = true;
             }
 
@@ -279,7 +278,7 @@
                 {
                     var options = provider.GetRequiredService<IOptions<ApplicationInsightsServiceOptions>>().Value;
 
-                    if(options.EnablePerformanceCounterCollectionModule)
+                    if (options.EnablePerformanceCounterCollectionModule)
                     {
                         return new PerformanceCollectorModule();
                     }
@@ -387,7 +386,7 @@
 
             services.ConfigureTelemetryModule<DependencyTrackingTelemetryModule>((module, o) =>
             {
-                if(o.EnableDependencyTrackingTelemetryModule)
+                if (o.EnableDependencyTrackingTelemetryModule)
                 {
                     module.EnableLegacyCorrelationHeadersInjection =
                        o.DependencyCollectionOptions.EnableLegacyCorrelationHeadersInjection;
@@ -419,11 +418,12 @@
                 eventCounterModule.Counters.Add(new EventCounterCollectionRequest(eventSource, eventCounterName));
             }
         }
+
         private static void ConfigureEventCounterModuleWithSystemCounters(IServiceCollection services)
         {
             services.ConfigureTelemetryModule<EventCounterCollectionModule>((eventCounterModule, options) =>
             {
-                if(options.EnableEventCounterCollectionModule)
+                if (options.EnableEventCounterCollectionModule)
                 {
                     // Ref this code for actual names. https://github.com/dotnet/coreclr/blob/dbc5b56c48ce30635ee8192c9814c7de998043d5/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/RuntimeEventSource.cs
                     AddEventCounterIfNotExist(eventCounterModule, EventSourceNameForSystemRuntime, "cpu-usage");
@@ -445,7 +445,7 @@
                     AddEventCounterIfNotExist(eventCounterModule, EventSourceNameForSystemRuntime, "threadpool-queue-length");
                     AddEventCounterIfNotExist(eventCounterModule, EventSourceNameForSystemRuntime, "threadpool-completed-items-count");
                     AddEventCounterIfNotExist(eventCounterModule, EventSourceNameForSystemRuntime, "active-timer-count");
-                }                        
+                }
             });
         }
 
@@ -464,7 +464,6 @@
             });
         }
 #endif
-
 
         private static void AddApplicationInsightsLoggerProvider(IServiceCollection services)
         {
@@ -493,8 +492,10 @@
                     options => options.Rules.Insert(
                         0,
                         new LoggerFilterRule(
-                            "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider", null,
-                            LogLevel.Warning, null)));
+                            "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider",
+                            null,
+                            LogLevel.Warning,
+                            null)));
             });
 #endif
         }

--- a/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
@@ -21,7 +21,7 @@
             this.EnablePerformanceCounterCollectionModule = true;
             this.EnableQuickPulseMetricStream = true;
             this.EnableAdaptiveSampling = true;
-            this.EnableDebugLogger = true;            
+            this.EnableDebugLogger = true;
             this.EnableHeartbeat = true;
             this.AddAutoCollectedMetricExtractor = true;
 #if AI_ASPNETCORE_WEB
@@ -35,52 +35,52 @@
 #endif
             this.EnableDependencyTrackingTelemetryModule = true;
             this.EnableAzureInstanceMetadataTelemetryModule = true;
-            this.EnableAppServicesHeartbeatTelemetryModule = true;            
+            this.EnableAppServicesHeartbeatTelemetryModule = true;
             this.DependencyCollectionOptions = new DependencyCollectionOptions();
             this.ApplicationVersion = Assembly.GetEntryAssembly()?.GetName().Version.ToString();
         }
 
         /// <summary>
         /// Gets or sets a value indicating whether QuickPulseTelemetryModule and QuickPulseTelemetryProcessor are registered with the configuration.
-        /// Setting EnableQuickPulseMetricStream to <c>false</c>, will disable the default quick pulse metric stream. Defaults to <code>true</code>.
+        /// Setting EnableQuickPulseMetricStream to <value>false</value>, will disable the default quick pulse metric stream. Defaults to <value>true</value>.
         /// </summary>
         public bool EnableQuickPulseMetricStream { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether PerformanceCollectorModule should be enabled.
-        /// Defaults to <code>true</code>.
+        /// Defaults to <value>true</value>.
         /// </summary>
         public bool EnablePerformanceCounterCollectionModule { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether AppServicesHeartbeatTelemetryModule should be enabled.
-        /// Defaults to <code>true</code>.
+        /// Defaults to <value>true</value>.
         /// </summary>
         public bool EnableAppServicesHeartbeatTelemetryModule { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether AzureInstanceMetadataTelemetryModule should be enabled.
-        /// Defaults to <code>true</code>.
+        /// Defaults to <value>true</value>.
         /// </summary>
         public bool EnableAzureInstanceMetadataTelemetryModule { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether DependencyTrackingTelemetryModule should be enabled.
-        /// Defaults to <code>true</code>.
+        /// Defaults to <value>true</value>.
         /// </summary>
-        public bool EnableDependencyTrackingTelemetryModule { get; set; }        
+        public bool EnableDependencyTrackingTelemetryModule { get; set; }
 
 #if NETSTANDARD2_0
         /// <summary>
         /// Gets or sets a value indicating whether EventCounterCollectionModule should be enabled.
-        /// Defaults to <code>true</code>.
+        /// Defaults to <value>true</value>.
         /// </summary>
         public bool EnableEventCounterCollectionModule { get; set; }
 #endif
 
         /// <summary>
         /// Gets or sets a value indicating whether telemetry processor that controls sampling is added to the service.
-        /// Setting EnableAdaptiveSampling to <c>false</c>, will disable the default adaptive sampling feature. Defaults to <code>true</code>.
+        /// Setting EnableAdaptiveSampling to <value>false</value>, will disable the default adaptive sampling feature. Defaults to <value>true</value>.
         /// </summary>
         public bool EnableAdaptiveSampling { get; set; }
 
@@ -107,7 +107,7 @@
         /// <summary>
         /// Gets or sets a value indicating whether a logger would be registered automatically in debug mode.
         /// </summary>
-        public bool EnableDebugLogger { get; set; }        
+        public bool EnableDebugLogger { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether heartbeats are enabled.
@@ -121,13 +121,13 @@
 
 #if AI_ASPNETCORE_WEB
         /// <summary>
-        /// Gets <see cref="RequestCollectionOptions"/> that allow to manage <see cref="RequestTrackingTelemetryModule"/>
+        /// Gets <see cref="RequestCollectionOptions"/> that allow to manage <see cref="RequestTrackingTelemetryModule"/>.
         /// </summary>
         public RequestCollectionOptions RequestCollectionOptions { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether RequestTrackingTelemetryModule should be enabled.
-        /// Defaults to <code>true</code>.
+        /// Defaults to <value>true</value>.
         /// </summary>
         public bool EnableRequestTrackingTelemetryModule { get; set; }
 
@@ -139,7 +139,7 @@
 #endif
 
         /// <summary>
-        /// Gets <see cref="DependencyCollectionOptions"/> that allow to manage <see cref="DependencyTrackingTelemetryModule"/>
+        /// Gets <see cref="DependencyCollectionOptions"/> that allow to manage <see cref="DependencyTrackingTelemetryModule"/>.
         /// </summary>
         public DependencyCollectionOptions DependencyCollectionOptions { get; }
 

--- a/src/Shared/Extensions/DependencyCollectionOptions.cs
+++ b/src/Shared/Extensions/DependencyCollectionOptions.cs
@@ -10,11 +10,11 @@ namespace Microsoft.ApplicationInsights.WorkerService
     public class DependencyCollectionOptions
     {
         /// <summary>
-        /// Creates new instance of <see cref="DependencyCollectionOptions"/> class and fills default values.
+        /// Initializes a new instance of the <see cref="DependencyCollectionOptions"/> class and fills default values.
         /// </summary>
         public DependencyCollectionOptions()
         {
-            EnableLegacyCorrelationHeadersInjection = false;
+            this.EnableLegacyCorrelationHeadersInjection = false;
         }
 
         /// <summary>

--- a/src/Shared/Implementation/ITelemetryModuleConfigurator.cs
+++ b/src/Shared/Implementation/ITelemetryModuleConfigurator.cs
@@ -1,7 +1,9 @@
-﻿#if AI_ASPNETCORE_WEB
+﻿using System;
+
+#if AI_ASPNETCORE_WEB
     namespace Microsoft.ApplicationInsights.AspNetCore
 #else
-    namespace Microsoft.ApplicationInsights.WorkerService
+namespace Microsoft.ApplicationInsights.WorkerService
 #endif
 {
 #if AI_ASPNETCORE_WEB
@@ -10,7 +12,6 @@
     using Microsoft.ApplicationInsights.WorkerService;
 #endif
     using Microsoft.ApplicationInsights.Extensibility;
-    using System;
 
     /// <summary>
     /// Represents method used to configure <see cref="ITelemetryModule"/> with dependency injection support.

--- a/src/Shared/Implementation/ITelemetryModuleConfigurator.cs
+++ b/src/Shared/Implementation/ITelemetryModuleConfigurator.cs
@@ -23,7 +23,7 @@
         Type TelemetryModuleType { get; }
 
         /// <summary>
-        /// Configures the given <see cref="ITelemetryModule"/>
+        /// Configures the given <see cref="ITelemetryModule"/>.
         /// </summary>
         [Obsolete("Use Configure(ITelemetryModule telemetryModule, ApplicationInsightsServiceOptions options) instead.")]
         void Configure(ITelemetryModule telemetryModule);

--- a/src/Shared/Implementation/NoOpTelemetryModule.cs
+++ b/src/Shared/Implementation/NoOpTelemetryModule.cs
@@ -1,12 +1,9 @@
-﻿using Microsoft.ApplicationInsights.Extensibility;
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Shared.Implementation
+﻿namespace Shared.Implementation
 {
+    using Microsoft.ApplicationInsights.Extensibility;
+
     /// <summary>
-    /// No-op telemetry module that is added instead of actual one, when the actual module is disabled
+    /// No-op telemetry module that is added instead of actual one, when the actual module is disabled.
     /// </summary>
     internal class NoOpTelemetryModule : ITelemetryModule
     {

--- a/src/Shared/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Shared/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -3,23 +3,23 @@ namespace Microsoft.Extensions.DependencyInjection
     using System;
     using System.Collections.Generic;
     using System.Linq;
+
 #if AI_ASPNETCORE_WEB
-    using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.AspNetCore;
+    using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.Tracing;
 #else
     using Microsoft.ApplicationInsights.WorkerService;
     using Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing;
 #endif
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
-    using Microsoft.ApplicationInsights.Extensibility.W3C;
-    using Microsoft.Extensions.Options;
     using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
-    using Microsoft.ApplicationInsights.DataContracts;    
+    using Microsoft.Extensions.Options;
 
     /// <summary>
     /// Initializes TelemetryConfiguration based on values in <see cref="ApplicationInsightsServiceOptions"/>
@@ -101,7 +101,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 this.AddQuickPulse(configuration);
                 this.AddSampling(configuration);
                 this.DisableHeartBeatIfConfigured();
-                
+
                 configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder.Build();
                 configuration.TelemetryProcessorChainBuilder.Build();
 

--- a/src/Shared/Implementation/TelemetryModuleConfigurator.cs
+++ b/src/Shared/Implementation/TelemetryModuleConfigurator.cs
@@ -30,6 +30,11 @@
             this.TelemetryModuleType = telemetryModuleType;
         }
 
+        /// <summary>
+        /// Gets the type of <see cref="ITelemetryModule"/> to be configured.
+        /// </summary>
+        public Type TelemetryModuleType { get; }
+
         [Obsolete("Use Configure(ITelemetryModule telemetryModule, ApplicationInsightsServiceOptions options) instead.", true)]
         public void Configure(ITelemetryModule telemetryModule)
         {
@@ -43,10 +48,5 @@
         {
             this.configure?.Invoke(telemetryModule, options);
         }
-
-        /// <summary>
-        /// Gets the type of <see cref="ITelemetryModule"/> to be configured.
-        /// </summary>
-        public Type TelemetryModuleType { get; }
     }
 }

--- a/src/Shared/Implementation/TelemetryProcessorFactory.cs
+++ b/src/Shared/Implementation/TelemetryProcessorFactory.cs
@@ -17,7 +17,7 @@
         private readonly Type telemetryProcessorType;
 
         /// <summary>
-        /// Constructs an instance of the factory.
+        /// Initializes a new instance of the <see cref="TelemetryProcessorFactory"/> class.
         /// </summary>
         /// <param name="serviceProvider">The service provider.</param>
         /// <param name="telemetryProcessorType">The type of telemetry processor to create.</param>

--- a/src/Shared/TelemetryInitializers/ComponentVersionTelemetryInitializer.cs
+++ b/src/Shared/TelemetryInitializers/ComponentVersionTelemetryInitializer.cs
@@ -4,8 +4,8 @@ namespace Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers
 namespace Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers
 #endif
 {
-    using ApplicationInsights.Extensibility;
-    using Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Channel;
 #if AI_ASPNETCORE_WEB
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 #else

--- a/src/Shared/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
+++ b/src/Shared/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
@@ -35,6 +35,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers
         private string GetMachineName()
         {
             string hostName = Dns.GetHostName();
+            
             // Issue #61: For dnxcore machine name does not have domain name like in full framework
 #if NET451 || NET46
             string domainName = IPGlobalProperties.GetIPGlobalProperties().DomainName;

--- a/src/Shared/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
+++ b/src/Shared/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
@@ -9,7 +9,8 @@ namespace Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers
     using System.Net;
     using System.Net.NetworkInformation;
     using System.Threading;
-    using Channel;
+
+    using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
 
     /// <summary>
@@ -35,7 +36,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers
         private string GetMachineName()
         {
             string hostName = Dns.GetHostName();
-            
+
             // Issue #61: For dnxcore machine name does not have domain name like in full framework
 #if NET451 || NET46
             string domainName = IPGlobalProperties.GetIPGlobalProperties().DomainName;


### PR DESCRIPTION
This is a prerequisite to requiring FxCop on check-ins.

**Warnings Count**
-  before 469
- after 299

**Changes**
- no functional changes
- fix whitespace.
- prefix local calls with this.
- include missing xml documentation.
- methods that don't access instance data can be marked static
- remove and sort usings
