### PR TITLE
fix fxcop warnings

### DIFF
--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -416,6 +416,7 @@
             this.OnException(httpContext, exception);
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             SubscriptionManager.Detach(this);

--- a/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HttpHeadersUtilities.cs
@@ -3,7 +3,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Net.Http.Headers;
+
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Primitives;
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
@@ -1,10 +1,4 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="AspNetCoreEventSource.cs" company="Microsoft">
-//     Copyright (c) Microsoft Corporation. All rights reserved.
-// </copyright>
-//-----------------------------------------------------------------------
-
-namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.Tracing
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.Tracing
 {
 #if AI_ASPNETCORE_WEB
     using Microsoft.ApplicationInsights.AspNetCore.Implementation;

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
@@ -8,6 +8,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
 {
 #if AI_ASPNETCORE_WEB
     using Microsoft.ApplicationInsights.AspNetCore.Implementation;
+    using Microsoft.ApplicationInsights.Shared.Internals;
 #endif
     using System;
     using System.Diagnostics.CodeAnalysis;
@@ -18,6 +19,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
     /// </summary>
     [EventSource(Name = "Microsoft-ApplicationInsights-AspNetCore")]
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
+    [SuppressMessage("", "SA1611:ElementParametersMustBeDocumented", Justification = "Internal only class.")]
     internal sealed class AspNetCoreEventSource : EventSource
     {
         /// <summary>
@@ -26,6 +28,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         /// a property otherwise the internal state of the event source will not be enabled.
         /// </summary>
         public static readonly AspNetCoreEventSource Instance = new AspNetCoreEventSource();
+        private readonly ApplicationNameProvider applicationNameProvider = new ApplicationNameProvider();
 
         /// <summary>
         /// Prevents a default instance of the <see cref="AspNetCoreEventSource"/> class from being created.
@@ -33,25 +36,6 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         private AspNetCoreEventSource()
             : base()
         {
-            try
-            {
-                this.ApplicationName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name;
-            }
-            catch (Exception exp)
-            {
-                this.ApplicationName = "Undefined " + exp.Message;
-            }
-        }
-
-        /// <summary>
-        /// Gets the application name for use in logging events.
-        /// </summary>
-        public string ApplicationName
-        {
-            [NonEvent]
-            get;
-            [NonEvent]
-            private set;
         }
 
         /// <summary>
@@ -61,7 +45,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         [Event(2, Message = "TelemetryInitializerBase.Initialize - httpContextAccessor.HttpContext is null, returning.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
         public void LogTelemetryInitializerBaseInitializeContextNull(string appDomainName = "Incorrect")
         {
-            this.WriteEvent(2, this.ApplicationName);
+            this.WriteEvent(2, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -71,7 +55,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         [Event(4, Message = "TelemetryInitializerBase.Initialize - request is null, returning.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
         public void LogTelemetryInitializerBaseInitializeRequestNull(string appDomainName = "Incorrect")
         {
-            this.WriteEvent(4, this.ApplicationName);
+            this.WriteEvent(4, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -81,7 +65,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         [Event(5, Message = "ClientIpHeaderTelemetryInitializer.OnInitializeTelemetry - telemetry.Context.Location.Ip is already set, returning.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
         public void LogClientIpHeaderTelemetryInitializerOnInitializeTelemetryIpNull(string appDomainName = "Incorrect")
         {
-            this.WriteEvent(5, this.ApplicationName);
+            this.WriteEvent(5, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -91,7 +75,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         [Event(6, Message = "WebSessionTelemetryInitializer.OnInitializeTelemetry - telemetry.Context.Session.Id is null or empty, returning.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
         public void LogWebSessionTelemetryInitializerOnInitializeTelemetrySessionIdNull(string appDomainName = "Incorrect")
         {
-            this.WriteEvent(6, this.ApplicationName);
+            this.WriteEvent(6, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -101,7 +85,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         [Event(7, Message = "WebUserTelemetryInitializer.OnInitializeTelemetry - telemetry.Context.Session.Id is null or empty, returning.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
         public void LogWebUserTelemetryInitializerOnInitializeTelemetrySessionIdNull(string appDomainName = "Incorrect")
         {
-            this.WriteEvent(7, this.ApplicationName);
+            this.WriteEvent(7, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -111,7 +95,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         [Event(9, Message = "HostingDiagnosticListener.OnHttpRequestInStart - Activity.Current is null, returning.", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
         public void LogHostingDiagnosticListenerOnHttpRequestInStartActivityNull(string appDomainName = "Incorrect")
         {
-            this.WriteEvent(9, this.ApplicationName);
+            this.WriteEvent(9, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -120,7 +104,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
         [Event(11, Message = "Unable to configure module {0} as it is not found in service collection.", Level = EventLevel.Error, Keywords = Keywords.Diagnostics)]
         public void UnableToFindModuleToConfigure(string moduleType, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(11, moduleType, this.ApplicationName);
+            this.WriteEvent(11, moduleType, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -133,7 +117,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Verbose)]
         public void NotActiveListenerNoTracking(string evntName, string activityId, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(13, evntName, activityId, this.ApplicationName);
+            this.WriteEvent(13, evntName, activityId, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -146,7 +130,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Error)]
         public void LogError(string errorMessage, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(14, errorMessage, this.ApplicationName);
+            this.WriteEvent(14, errorMessage, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -159,7 +143,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Error)]
         public void RequestTrackingModuleInitializationFailed(string errorMessage, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(15, errorMessage, this.ApplicationName);
+            this.WriteEvent(15, errorMessage, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -172,7 +156,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Warning)]
         public void DiagnosticListenerWarning(string callback, string errorMessage, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(16, callback, errorMessage, this.ApplicationName);
+            this.WriteEvent(16, callback, errorMessage, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -185,7 +169,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Error)]
         public void TelemetryConfigurationSetupFailure(string errorMessage, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(17, errorMessage, this.ApplicationName);
+            this.WriteEvent(17, errorMessage, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -198,7 +182,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Verbose)]
         public void TelemetryItemWasSampledOutAtHead(string operationId, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(18, operationId, this.ApplicationName);
+            this.WriteEvent(18, operationId, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -210,7 +194,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Informational)]
         public void HostingListenerInformational(AspNetCoreMajorVersion hostingVersion, string message, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(19, hostingVersion, message, this.ApplicationName);
+            this.WriteEvent(19, hostingVersion, message, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -222,7 +206,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Verbose)]
         public void HostingListenerVerbose(string message, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(20, message, this.ApplicationName);
+            this.WriteEvent(20, message, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -234,7 +218,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Informational)]
         public void RequestTelemetryCreated(string correlationFormat, string requestId, string requestOperationId, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(21, correlationFormat, requestId, requestOperationId, this.ApplicationName);
+            this.WriteEvent(21, correlationFormat, requestId, requestOperationId, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -246,7 +230,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Warning)]
         public void HostingListenerWarning(string message, string exception, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(22, message, exception, this.ApplicationName);
+            this.WriteEvent(22, message, exception, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -258,7 +242,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.
             Level = EventLevel.Informational)]
         public void LogInformational(string message, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(23, message, this.ApplicationName);
+            this.WriteEvent(23, message, this.applicationNameProvider.Name);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/AspNetCoreMajorVersion.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Implementation/AspNetCoreMajorVersion.cs
@@ -5,5 +5,5 @@
         One,
         Two,
         Three,
-    };
+    }
 }

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerFactoryExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerFactoryExtensions.cs
@@ -9,7 +9,8 @@
     /// <summary>
     /// Extension methods for <see cref="ILoggerFactory"/> that allow adding Application Insights logger.
     /// </summary>
-    [SuppressMessage("Microsoft.Usage", "SA1614ElementParameterDocumentationMustHaveText", Justification = "Obsolete class")]
+    [SuppressMessage("Microsoft.Usage", "SA1614:ElementParameterDocumentationMustHaveText", Justification = "Obsolete class")]
+    [SuppressMessage("Microsoft.Usage", "SA1615:ElementReturnValueMustBeDocumented", Justification = "Obsolete class")]
     public static class ApplicationInsightsLoggerFactoryExtensions
     {
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Microsoft.ApplicationInsights.AspNetCore.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 [assembly: ComVisible(false)]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "SDK intentionally catch ALL exceptions and never re-throws.")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "<Pending>")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "Unnecessary.")]

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Properties/AssemblyInfo.cs
@@ -4,3 +4,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Microsoft.ApplicationInsights.AspNetCore.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 [assembly: ComVisible(false)]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "SDK intentionally catch ALL exceptions and never re-throws.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "<Pending>")]

--- a/src/Microsoft.ApplicationInsights.AspNetCore/SdkVersionUtils.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/SdkVersionUtils.cs
@@ -3,6 +3,9 @@
     using System.Linq;
     using System.Reflection;
 
+    /// <summary>
+    /// Utility class for the version information of the current assembly.
+    /// </summary>
     internal class SdkVersionUtils
     {
 #if NET451 || NET46
@@ -14,7 +17,7 @@
         /// <summary>
         /// Get the Assembly Version with SDK prefix.
         /// </summary>
-        /// <returns>assembly version prefixed with versionprefix.</returns>
+        /// <returns>Assembly version combined with this assembly's version prefix.</returns>
         internal static string GetVersion()
         {
             return VersionPrefix + GetAssemblyVersion();
@@ -23,6 +26,8 @@
         /// <summary>
         /// Get the Assembly Version with given SDK prefix.
         /// </summary>
+        /// <param name="versionPrefix">Prefix string to be included with the version.</param>
+        /// <returns>Returns a string representing the current assembly version.</returns>
         internal static string GetVersion(string versionPrefix)
         {
             return versionPrefix + GetAssemblyVersion();

--- a/src/Microsoft.ApplicationInsights.WorkerService/Implementation/Tracing/WorkerServiceEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.WorkerService/Implementation/Tracing/WorkerServiceEventSource.cs
@@ -1,20 +1,16 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="WorkerServiceEventSource.cs" company="Microsoft">
-//     Copyright (c) Microsoft Corporation. All rights reserved.
-// </copyright>
-//-----------------------------------------------------------------------
-
-namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
+﻿namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
+    using Microsoft.ApplicationInsights.Shared.Internals;
 
     /// <summary>
     /// Event source for Application Insights Worker Service SDK.
     /// </summary>
     [EventSource(Name = "Microsoft-ApplicationInsights-WorkerService")]
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
+    [SuppressMessage("", "SA1611:ElementParametersMustBeDocumented", Justification = "Internal only class.")]
     internal sealed class WorkerServiceEventSource : EventSource
     {
         /// <summary>
@@ -23,6 +19,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         /// a property otherwise the internal state of the event source will not be enabled.
         /// </summary>
         public static readonly WorkerServiceEventSource Instance = new WorkerServiceEventSource();
+        private readonly ApplicationNameProvider applicationNameProvider = new ApplicationNameProvider();
 
         /// <summary>
         /// Prevents a default instance of the <see cref="WorkerServiceEventSource"/> class from being created.
@@ -30,25 +27,6 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         private WorkerServiceEventSource()
             : base()
         {
-            try
-            {
-                this.ApplicationName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name;
-            }
-            catch (Exception exp)
-            {
-                this.ApplicationName = "Undefined " + exp.Message;
-            }
-        }
-
-        /// <summary>
-        /// Gets the application name for use in logging events.
-        /// </summary>
-        public string ApplicationName
-        {
-            [NonEvent]
-            get;
-            [NonEvent]
-            private set;
         }
 
         /// <summary>
@@ -59,7 +37,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         [Event(1, Message = "Message : {0}", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
         public void LogInformational(string message, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(1, message, this.ApplicationName);
+            this.WriteEvent(1, message, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -70,7 +48,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         [Event(2, Message = "Message : {0}", Level = EventLevel.Warning)]
         public void LogWarning(string message, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(2, message, this.ApplicationName);
+            this.WriteEvent(2, message, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -81,7 +59,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         [Event(3, Message = "An error has occurred which may prevent application insights from functioning. Error message: '{0}'", Level = EventLevel.Error)]
         public void LogError(string message, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(3, message, this.ApplicationName);
+            this.WriteEvent(3, message, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -90,7 +68,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         [Event(4, Message = "Unable to configure module {0} as it is not found in service collection.", Level = EventLevel.Error, Keywords = Keywords.Diagnostics)]
         public void UnableToFindModuleToConfigure(string moduleType, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(4, moduleType, this.ApplicationName);
+            this.WriteEvent(4, moduleType, this.applicationNameProvider.Name);
         }
 
         /// <summary>
@@ -99,7 +77,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing
         [Event(5, Keywords = Keywords.Diagnostics, Message = "An error has occurred while setting up TelemetryConfiguration. Error message: '{0}' ", Level = EventLevel.Error)]
         public void TelemetryConfigurationSetupFailure(string errorMessage, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(5, errorMessage, this.ApplicationName);
+            this.WriteEvent(5, errorMessage, this.applicationNameProvider.Name);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights.WorkerService/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ApplicationInsights.WorkerService/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "<Pending>")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "Unnecessary.")]

--- a/src/Microsoft.ApplicationInsights.WorkerService/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ApplicationInsights.WorkerService/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "<Pending>")]

--- a/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -8,31 +8,37 @@
     using Microsoft.ApplicationInsights;
 #if AI_ASPNETCORE_WEB
     using Microsoft.ApplicationInsights.AspNetCore;
-    using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
     using Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
-#else
+    using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
+#endif
+
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DependencyCollector;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+#if NETSTANDARD2_0
+    using Microsoft.ApplicationInsights.Extensibility.EventCounterCollector;
+#endif
+
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
+    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
+    using Microsoft.ApplicationInsights.WindowsServer;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
+
+#if AI_ASPNETCORE_WORKER
     using Microsoft.ApplicationInsights.WorkerService;
     using Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers;
     using Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing;
 #endif
-    using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-    using Microsoft.ApplicationInsights.WindowsServer;
+
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Configuration.Memory;
-    using Microsoft.Extensions.Logging;
-    using Microsoft.ApplicationInsights.DependencyCollector;
-    using Microsoft.ApplicationInsights.Channel;
     using Microsoft.Extensions.DependencyInjection.Extensions;
-    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
-    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
-    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
-#if NETSTANDARD2_0
-    using Microsoft.ApplicationInsights.Extensibility.EventCounterCollector;
-#endif
+    using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
 
     using Shared.Implementation;
 

--- a/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -164,7 +164,8 @@
 
             if (developerMode != null)
             {
-                telemetryConfigValues.Add(new KeyValuePair<string, string>(DeveloperModeForWebSites,
+                telemetryConfigValues.Add(new KeyValuePair<string, string>(
+                    DeveloperModeForWebSites,
 #if !NETSTANDARD1_6
                     developerMode.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)));
 #else

--- a/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -30,8 +30,8 @@
 
 #if AI_ASPNETCORE_WORKER
     using Microsoft.ApplicationInsights.WorkerService;
-    using Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers;
     using Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers;
 #endif
 
     using Microsoft.Extensions.Configuration;

--- a/src/Shared/Implementation/ITelemetryModuleConfigurator.cs
+++ b/src/Shared/Implementation/ITelemetryModuleConfigurator.cs
@@ -1,11 +1,11 @@
-﻿using System;
-
-#if AI_ASPNETCORE_WEB
+﻿#if AI_ASPNETCORE_WEB
     namespace Microsoft.ApplicationInsights.AspNetCore
 #else
 namespace Microsoft.ApplicationInsights.WorkerService
 #endif
 {
+    using System;
+
 #if AI_ASPNETCORE_WEB
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 #else

--- a/src/Shared/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/src/Shared/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
 #if AI_ASPNETCORE_WEB
     using Microsoft.ApplicationInsights.AspNetCore;
-    using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 #else
     using Microsoft.ApplicationInsights.WorkerService;
     using Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing;

--- a/src/Shared/Internals/ApplicationNameProvider.cs
+++ b/src/Shared/Internals/ApplicationNameProvider.cs
@@ -1,0 +1,36 @@
+﻿namespace Microsoft.ApplicationInsights.Shared.Internals
+{
+    using System;
+    using System.Reflection;
+
+    /// <summary>
+    /// This class provides the assembly name for the EventSource implementations.
+    /// </summary>
+    internal sealed class ApplicationNameProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationNameProvider"/> class.
+        /// </summary>
+        public ApplicationNameProvider()
+        {
+            this.Name = GetApplicationName();
+        }
+
+        /// <summary>
+        /// Gets name of the current assembly.
+        /// </summary>
+        public string Name { get; private set; }
+
+        private static string GetApplicationName()
+        {
+            try
+            {
+                return Assembly.GetEntryAssembly().GetName().Name;
+            }
+            catch (Exception exp)
+            {
+                return "Undefined " + exp.Message;
+            }
+        }
+    }
+}

--- a/src/Shared/Shared.projitems
+++ b/src/Shared/Shared.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>d56f2979-d6bc-4ef2-bb9b-4077b3290599</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Shared</Import_RootNamespace>
+    <Import_RootNamespace>Microsoft.ApplicationInsights.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ApplicationInsightsExtensions.cs" />
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\TelemetryConfigurationOptionsSetup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\TelemetryModuleConfigurator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\TelemetryProcessorFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internals\ApplicationNameProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TelemetryInitializers\ComponentVersionTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TelemetryInitializers\DomainNameRoleInstanceTelemetryInitializer.cs" />
   </ItemGroup>

--- a/src/Shared/TelemetryInitializers/ComponentVersionTelemetryInitializer.cs
+++ b/src/Shared/TelemetryInitializers/ComponentVersionTelemetryInitializer.cs
@@ -4,8 +4,8 @@ namespace Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers
 namespace Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers
 #endif
 {
-    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
 #if AI_ASPNETCORE_WEB
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 #else


### PR DESCRIPTION
This is a prerequisite to requiring FxCop on check-ins.

**Warnings Count**
-  before 299
- after 111 (only counting product code, 189 including tests)

**Changes**
- no functional changes
- fix whitespace.
- fix usings
- include missing xml documentation.
- disable file header rule
