### PR TITLE
Tilee/fxcop

### DIFF
--- a/test/EmptyApp.FunctionalTests/App.config
+++ b/test/EmptyApp.FunctionalTests/App.config
@@ -3,10 +3,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.1.1" />
       </dependentAssembly>

--- a/test/EmptyApp20.FunctionalTests/App.config
+++ b/test/EmptyApp20.FunctionalTests/App.config
@@ -2,14 +2,6 @@
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.1.1" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/MVCFramework.FunctionalTests/App.config
+++ b/test/MVCFramework.FunctionalTests/App.config
@@ -2,14 +2,6 @@
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.1.1" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests10.csproj
+++ b/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests10.csproj
@@ -52,12 +52,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/App.config
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/App.config
@@ -3,10 +3,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.1.1" />
       </dependentAssembly>

--- a/test/WebApi.FunctionalTests/App.config
+++ b/test/WebApi.FunctionalTests/App.config
@@ -3,10 +3,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="4.0.0.0" newVersion="4.0.1.1" />
       </dependentAssembly>

--- a/test/WebApi.FunctionalTests/WebApi.FunctionalTests10.csproj
+++ b/test/WebApi.FunctionalTests/WebApi.FunctionalTests10.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="1.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.4" />    
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.0" />    
 	  <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
**Warnings Count**

- before 189 (intcluding tests)
- after 166

**Changes**

- we upgraded our product to System.Diagnostics.DiagnosticSource 4.0.6 in the most recent release. Removing binding redirects from test projects.

- Fixing the following errors:


MSB3836	The explicit binding redirect on "System.Diagnostics.DiagnosticSource, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "<bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" xmlns="urn:schemas-microsoft-com:asm.v1" />".	Microsoft.ApplicationInsights.AspNetCore.Tests	C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets	2220	

MSB3836	The explicit binding redirect on "System.Text.Encodings.Web, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" conflicts with an autogenerated binding redirect. Consider removing it from the application configuration file or disabling autogenerated binding redirects. The build will replace it with: "<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" xmlns="urn:schemas-microsoft-com:asm.v1" />".	EmptyApp20.FunctionalTests20	C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets	2220	

NU1603	MVCFramework.FunctionalTests depends on Microsoft.Extensions.Configuration.FileExtensions (>= 1.0.4) but Microsoft.Extensions.Configuration.FileExtensions 1.0.4 was not found. An approximate best match of Microsoft.Extensions.Configuration.FileExtensions 1.1.0 was resolved.	MVCFramework.FunctionalTests10	D:\SDK\ApplicationInsights-aspnetcore\test\MVCFramework.FunctionalTests\MVCFramework.FunctionalTests10.csproj	1	

NU1603	MVCFramework.FunctionalTests depends on Microsoft.Extensions.Configuration.Json (>= 1.0.4) but Microsoft.Extensions.Configuration.Json 1.0.4 was not found. An approximate best match of Microsoft.Extensions.Configuration.Json 1.1.0 was resolved.	MVCFramework.FunctionalTests10	D:\SDK\ApplicationInsights-aspnetcore\test\MVCFramework.FunctionalTests\MVCFramework.FunctionalTests10.csproj	1	
