### PR TITLE
Add new RoleName initializer for Azure Web App to accurately reflect slot swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Skipping version numbers to keep in sync with Base SDK.
 - [Fix Null/Empty Ikey from ApplicationInsightsServiceOptions overrding one from appsettings.json](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/989)
 - [Provide ApplicationInsightsServiceOptions for easy disabling of any default TelemetryModules](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/988)
+- [New RoleName initializer for Azure Web App to accurately populate RoleName.](https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1207)
 
 ## Version 2.8.0
 - Updated Bask SDK/Web SDK/Logging Adaptor SDK to 2.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - [Fix Null/Empty Ikey from ApplicationInsightsServiceOptions overrding one from appsettings.json](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/989)
 - [Provide ApplicationInsightsServiceOptions for easy disabling of any default TelemetryModules](https://github.com/microsoft/ApplicationInsights-aspnetcore/issues/988)
 - [Added support for SDK Connection String](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1221)
-
 - [New RoleName initializer for Azure Web App to accurately populate RoleName.](https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1207)
 
 ## Version 2.8.0

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
@@ -240,6 +240,17 @@
         }
 
         /// <summary>
+        /// Logs an event when AzureAppServiceRoleNameFromHostNameHeaderInitializer faces errors.
+        /// </summary>
+        /// <param name="exception">Exception message.</param>
+        /// <param name="appDomainName">An ignored placeholder to make EventSource happy.</param>
+        [Event(24, Message = "An error has occured in AzureAppServiceRoleNameFromHostNameHeaderInitializer. Exception: '{0}'", Level = EventLevel.Warning, Keywords = Keywords.Diagnostics)]
+        public void LogAzureAppServiceRoleNameFromHostNameHeaderInitializerWarning(string exception, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(24, exception, this.applicationNameProvider.Name);
+        }
+
+        /// <summary>
         /// Keywords for the AspNetEventSource.
         /// </summary>
         public sealed class Keywords

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -196,6 +196,7 @@
 
         private static void AddAspNetCoreWebTelemetryInitializers(IServiceCollection services)
         {
+            services.AddSingleton<ITelemetryInitializer, AzureAppServiceRoleNameFromHostNameHeaderInitializer>();
             services.AddSingleton<ITelemetryInitializer, ClientIpHeaderTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, OperationNameTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, SyntheticTelemetryInitializer>();

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -1,35 +1,21 @@
 ﻿namespace Microsoft.Extensions.DependencyInjection
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
-    using System.Reflection;
-
-    using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.AspNetCore;
     using Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
-    using Microsoft.ApplicationInsights.Channel;
-    using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility;
 #if NETSTANDARD2_0
     using Microsoft.ApplicationInsights.Extensibility.EventCounterCollector;
 #endif
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
-    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
-    using Microsoft.ApplicationInsights.WindowsServer;
-    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.Configuration.Memory;
     using Microsoft.Extensions.DependencyInjection.Extensions;
-    using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
     using Shared.Implementation;
 

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializer.cs
@@ -1,0 +1,149 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers
+{
+    using System;
+    using Microsoft.ApplicationInsights.AspNetCore.Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+    using Microsoft.AspNetCore.Http;
+
+    /// <summary>
+    /// A telemetry initializer that will gather Azure Web App Role Environment context information to
+    /// populate TelemetryContext.Cloud.RoleName
+    /// This uses the http header "WAS-DEFAULT-HOSTNAME" to update role name, if available.
+    /// Otherwise role name is populated from "WEBSITE_HOSTNAME" environment variable.
+    /// </summary>
+    /// <remarks>
+    /// The RoleName is expected to contain the host name + slot name, but will be same across all instances of
+    /// a single App Service.
+    /// Populating RoleName from HOSTNAME environment variable will cause RoleName to be incorrect when a slot swap occurs in AppService.
+    /// The most accurate way to determine the RoleName is to rely on the header WAS-DEFAULT-HOSTNAME, as its
+    /// populated from App service front end on every request. Slot swaps are instantly reflected in this header.
+    /// </remarks>
+    public class AzureAppServiceRoleNameFromHostNameHeaderInitializer : ITelemetryInitializer
+    {
+        private const string WebAppHostNameHeaderName = "WAS-DEFAULT-HOSTNAME";
+        private const string WebAppHostNameEnvironmentVariable = "WEBSITE_HOSTNAME";
+        private readonly IHttpContextAccessor httpContextAccessor;
+        private string roleName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureAppServiceRoleNameFromHostNameHeaderInitializer" /> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">Accessor to provide HttpContext if available.</param>
+        public AzureAppServiceRoleNameFromHostNameHeaderInitializer(IHttpContextAccessor httpContextAccessor)
+        {
+            this.httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+
+            try
+            {
+                var result = Environment.GetEnvironmentVariable(WebAppHostNameEnvironmentVariable);
+
+                if (!string.IsNullOrEmpty(result) && result.EndsWith(this.WebAppSuffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    result = result.Substring(0, result.Length - this.WebAppSuffix.Length);
+                }
+
+                this.roleName = result;
+            }
+            catch (Exception ex)
+            {
+                AspNetCoreEventSource.Instance.LogAzureAppServiceRoleNameFromHostNameHeaderInitializerWarning(ex.ToInvariantString());
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets suffix of website name. This must be changed when running in non public Azure region.
+        /// Default value (Public Cloud):  ".azurewebsites.net"
+        /// For US Gov Cloud: ".azurewebsites.us"
+        /// For Azure Germany: ".azurewebsites.de".
+        /// </summary>
+        public string WebAppSuffix { get; set; } = ".azurewebsites.net";
+
+        /// <summary>
+        /// Populates RoleName from the request telemetry associated with the http context.
+        /// If RoleName is empty on the request telemetry, it'll be updated as well so that other telemetry
+        /// belonging to the same requests gets it from request telemetry, without having to parse headers again.
+        /// </summary>
+        /// <remarks>
+        /// RoleName is attempted from every incoming request as opposed to doing this periodically. This is
+        /// done to ensure every request (and associated telemetry) gets the correct RoleName during slot swap.
+        /// </remarks>
+        /// <param name="telemetry">The telemetry item for which RoleName is to be set.</param>
+        public void Initialize(ITelemetry telemetry)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+                {
+                    // RoleName is already populated.
+                    return;
+                }
+
+                string roleName = string.Empty;
+                var context = this.httpContextAccessor.HttpContext;
+
+                if (context != null)
+                {
+                    lock (context)
+                    {
+                        var request = context.Features.Get<RequestTelemetry>();
+
+                        if (request != null)
+                        {
+                            if (string.IsNullOrEmpty(request.Context.Cloud.RoleName))
+                            {
+                                roleName = this.GetRoleNameFromHeader(context);
+                                if (!string.IsNullOrEmpty(roleName))
+                                {
+                                    request.Context.Cloud.RoleName = roleName;
+                                }
+                            }
+                            else
+                            {
+                                roleName = request.Context.Cloud.RoleName;
+                            }
+                        }
+                        else
+                        {
+                            roleName = this.GetRoleNameFromHeader(context);
+                        }
+                    }
+                }
+
+                if (string.IsNullOrEmpty(roleName))
+                {
+                    // Fallback to value from ENV variable.
+                    roleName = this.roleName;
+                }
+
+                telemetry.Context.Cloud.RoleName = roleName;
+            }
+            catch (Exception ex)
+            {
+                AspNetCoreEventSource.Instance.LogAzureAppServiceRoleNameFromHostNameHeaderInitializerWarning(ex.ToInvariantString());
+            }
+        }
+
+        private string GetRoleNameFromHeader(HttpContext context)
+        {
+            string roleName = string.Empty;
+            if (context.Request?.Headers != null)
+            {
+                string headerValue = context.Request.Headers[WebAppHostNameHeaderName];
+                if (!string.IsNullOrEmpty(headerValue))
+                {
+                    if (headerValue.EndsWith(this.WebAppSuffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        headerValue = headerValue.Substring(0, headerValue.Length - this.WebAppSuffix.Length);
+                    }
+
+                    roleName = headerValue;
+                }
+            }
+
+            return roleName;
+        }
+    }
+}

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializer.cs
@@ -27,6 +27,7 @@
         private const string WebAppHostNameEnvironmentVariable = "WEBSITE_HOSTNAME";
         private readonly IHttpContextAccessor httpContextAccessor;
         private string roleName;
+        private bool isAzureWebApp;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureAppServiceRoleNameFromHostNameHeaderInitializer" /> class.
@@ -50,6 +51,7 @@
             try
             {
                 var result = Environment.GetEnvironmentVariable(WebAppHostNameEnvironmentVariable);
+                this.isAzureWebApp = !string.IsNullOrEmpty(result);
 
                 if (!string.IsNullOrEmpty(result) && result.EndsWith(this.WebAppSuffix, StringComparison.OrdinalIgnoreCase))
                 {
@@ -86,6 +88,12 @@
         {
             try
             {
+                if (!this.isAzureWebApp)
+                {
+                    // return immediately if not azure web app.
+                    return;
+                }
+
                 if (!string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
                 {
                     // RoleName is already populated.

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializer.cs
@@ -33,8 +33,19 @@
         /// </summary>
         /// <param name="httpContextAccessor">Accessor to provide HttpContext if available.</param>
         public AzureAppServiceRoleNameFromHostNameHeaderInitializer(IHttpContextAccessor httpContextAccessor)
+            : this(httpContextAccessor, ".azurewebsites.net")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureAppServiceRoleNameFromHostNameHeaderInitializer" /> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">Accessor to provide HttpContext if available.</param>
+        /// <param name="webAppSuffix">WebApp name suffix.</param>
+        public AzureAppServiceRoleNameFromHostNameHeaderInitializer(IHttpContextAccessor httpContextAccessor, string webAppSuffix)
         {
             this.httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+            this.WebAppSuffix = webAppSuffix;
 
             try
             {
@@ -59,7 +70,7 @@
         /// For US Gov Cloud: ".azurewebsites.us"
         /// For Azure Germany: ".azurewebsites.de".
         /// </summary>
-        public string WebAppSuffix { get; set; } = ".azurewebsites.net";
+        public string WebAppSuffix { get; set; }
 
         /// <summary>
         /// Populates RoleName from the request telemetry associated with the http context.

--- a/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializer.cs
@@ -94,8 +94,7 @@
                         {
                             if (string.IsNullOrEmpty(request.Context.Cloud.RoleName))
                             {
-                                roleName = this.GetRoleNameFromHeader(context);
-                                if (!string.IsNullOrEmpty(roleName))
+                                if (this.TryGetRoleNameFromHeader(context, out roleName))
                                 {
                                     request.Context.Cloud.RoleName = roleName;
                                 }
@@ -107,7 +106,10 @@
                         }
                         else
                         {
-                            roleName = this.GetRoleNameFromHeader(context);
+                            if (!this.TryGetRoleNameFromHeader(context, out roleName))
+                            {
+                                roleName = this.roleName;
+                            }
                         }
                     }
                 }
@@ -126,9 +128,10 @@
             }
         }
 
-        private string GetRoleNameFromHeader(HttpContext context)
+        private bool TryGetRoleNameFromHeader(HttpContext context, out string roleName)
         {
-            string roleName = string.Empty;
+            roleName = string.Empty;
+
             if (context.Request?.Headers != null)
             {
                 string headerValue = context.Request.Headers[WebAppHostNameHeaderName];
@@ -140,10 +143,11 @@
                     }
 
                     roleName = headerValue;
+                    return true;
                 }
             }
 
-            return roleName;
+            return false;
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
+++ b/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
@@ -1,8 +1,9 @@
 ﻿namespace Microsoft.Extensions.DependencyInjection
 {
     using System;
-
+    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.WindowsServer;
     using Microsoft.ApplicationInsights.WorkerService;
     using Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing;
     using Microsoft.Extensions.Configuration;
@@ -89,6 +90,7 @@
             {
                 if (!IsApplicationInsightsAdded(services))
                 {
+                    services.AddSingleton<ITelemetryInitializer, AzureWebAppRoleEnvironmentTelemetryInitializer>();
                     AddCommonInitializers(services);
                     AddCommonTelemetryModules(services);
                     AddTelemetryChannel(services);

--- a/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -273,8 +273,7 @@
             services.AddSingleton<ITelemetryInitializer, Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer>();
 #else
             services.AddSingleton<ITelemetryInitializer, Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer>();
-#endif
-            services.AddSingleton<ITelemetryInitializer, AzureWebAppRoleEnvironmentTelemetryInitializer>();
+#endif            
             services.AddSingleton<ITelemetryInitializer, HttpDependenciesParsingTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer, ComponentVersionTelemetryInitializer>();
         }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             [Theory]
             [InlineData(typeof(ITelemetryInitializer), typeof(ApplicationInsights.AspNetCore.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer), ServiceLifetime.Singleton)]
-            [InlineData(typeof(ITelemetryInitializer), typeof(AzureWebAppRoleEnvironmentTelemetryInitializer), ServiceLifetime.Singleton)]            
+            [InlineData(typeof(ITelemetryInitializer), typeof(AzureAppServiceRoleNameFromHostNameHeaderInitializer), ServiceLifetime.Singleton)]            
             [InlineData(typeof(ITelemetryInitializer), typeof(ComponentVersionTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(ClientIpHeaderTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(OperationNameTelemetryInitializer), ServiceLifetime.Singleton)]

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
 
             [Theory]
             [InlineData(typeof(ITelemetryInitializer), typeof(ApplicationInsights.AspNetCore.TelemetryInitializers.DomainNameRoleInstanceTelemetryInitializer), ServiceLifetime.Singleton)]
-            [InlineData(typeof(ITelemetryInitializer), typeof(AzureWebAppRoleEnvironmentTelemetryInitializer), ServiceLifetime.Singleton)]            
+            [InlineData(typeof(ITelemetryInitializer), typeof(AzureAppServiceRoleNameFromHostNameHeaderInitializer), ServiceLifetime.Singleton)]            
             [InlineData(typeof(ITelemetryInitializer), typeof(ComponentVersionTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(ClientIpHeaderTelemetryInitializer), ServiceLifetime.Singleton)]
             [InlineData(typeof(ITelemetryInitializer), typeof(OperationNameTelemetryInitializer), ServiceLifetime.Singleton)]

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>net46</TargetFrameworks>
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializerTests.cs
@@ -10,8 +10,13 @@
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Http.Features;
 
-    public class AzureAppServiceRoleNameFromHostNameHeaderInitializerTests
+    public class AzureAppServiceRoleNameFromHostNameHeaderInitializerTests : IDisposable
     {
+        public AzureAppServiceRoleNameFromHostNameHeaderInitializerTests()
+        {
+            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "SomeName");
+        }
+
         [Fact]
         public void InitializeThrowIfHttpContextAccessorIsNull()
         {
@@ -337,6 +342,7 @@
         [Fact]
         public void InitializewithNoEnvToHostNameHeader()
         {
+            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
             var ac = new HttpContextAccessor { HttpContext = null };
 
             var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(ac);
@@ -344,6 +350,11 @@
             var requestTelemetry = new RequestTelemetry();
             initializer.Initialize(requestTelemetry);
             Assert.Null(requestTelemetry.Context.Cloud.RoleName);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
         }
     }
 }

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializerTests.cs
@@ -1,0 +1,333 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
+{
+    using System;
+    using System.Net;
+
+    using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
+    using Microsoft.ApplicationInsights.AspNetCore.Tests.Helpers;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Xunit;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Http.Features;
+
+    public class AzureAppServiceRoleNameFromHostNameHeaderInitializerTests
+    {
+        [Fact]
+        public void InitializeThrowIfHttpContextAccessorIsNull()
+        {
+            Assert.ThrowsAny<ArgumentNullException>(() => { var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(null);  });
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowIfHttpContextIsUnavailable()
+        {
+            var ac = new HttpContextAccessor { HttpContext = null };
+            
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(ac);
+
+            initializer.Initialize(new RequestTelemetry());
+        }
+
+        [Fact]
+        public void InitializeFallsbackToEnvIfHttpContextIsUnavailable()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "RoleNameEnv");
+                var ac = new HttpContextAccessor { HttpContext = null };
+
+                var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(ac);
+                var req = new RequestTelemetry();
+                initializer.Initialize(req);
+
+                Assert.Equal("RoleNameEnv", req.Context.Cloud.RoleName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            }
+        }
+
+        [Fact]
+        public void InitializeFallsbackToEnvIfHttpContextIsUnavailableWithAzureWebsitesHostnameending()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "RoleNameEnv.azurewebsites.net");
+                var ac = new HttpContextAccessor { HttpContext = null };
+
+                var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(ac);
+                var req = new RequestTelemetry();
+                initializer.Initialize(req);
+
+                Assert.Equal("RoleNameEnv", req.Context.Cloud.RoleName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            }
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowIfRequestServicesAreUnavailable()
+        {
+            var ac = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+            
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(ac);
+
+            initializer.Initialize(new RequestTelemetry());
+        }
+
+        [Fact]
+        public void InitializeFallsbackToEnvIfRequestServicesAreUnavailable()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "RoleNameEnv");
+                var ac = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+
+                var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(ac);
+                var req = new RequestTelemetry();
+                initializer.Initialize(req);
+
+                Assert.Equal("RoleNameEnv", req.Context.Cloud.RoleName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            }
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowIfRequestIsUnavailable()
+        {
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessorWithoutRequest(new HttpContextStub(), new RequestTelemetry());
+            
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+
+            initializer.Initialize(new EventTelemetry());
+        }
+
+        [Fact]
+        public void InitializeFallsbackToEnvIfRequestIsUnavailable()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "RoleNameEnv");
+                var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessorWithoutRequest(new HttpContextStub(), new RequestTelemetry());
+
+                var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+                var req = new RequestTelemetry();
+                initializer.Initialize(req);
+
+                Assert.Equal("RoleNameEnv", req.Context.Cloud.RoleName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            }
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowIfHeaderCollectionIsUnavailable()
+        {
+            var httpContext = new HttpContextStub();
+            httpContext.OnRequestGetter = () => new HttpRequestStub(httpContext);
+
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessorWithoutRequest(httpContext, new RequestTelemetry());
+
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+
+            initializer.Initialize(new EventTelemetry());
+        }
+
+        [Fact]
+        public void InitializeFallsbackToEnvIfHeaderCollectionIsUnavailable()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "RoleNameEnv");
+                var httpContext = new HttpContextStub();
+                httpContext.OnRequestGetter = () => new HttpRequestStub(httpContext);
+
+                var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessorWithoutRequest(httpContext, new RequestTelemetry());
+
+                var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+                var req = new RequestTelemetry();
+                initializer.Initialize(req);
+
+                Assert.Equal("RoleNameEnv", req.Context.Cloud.RoleName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            }
+        }
+
+        [Fact]
+        public void InitializeDoesNotThrowIfHostNameHeaderIsNull()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
+
+            contextAccessor.HttpContext.Features.Set<IHttpConnectionFeature>(new HttpConnectionFeature());
+           
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+
+            initializer.Initialize(requestTelemetry);
+        }
+
+        [Fact]
+        public void InitializeFallsbackToEnvIfHostNameHeaderIsNull()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "RoleNameEnv");
+                var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor();
+
+                contextAccessor.HttpContext.Features.Set<IHttpConnectionFeature>(new HttpConnectionFeature());
+
+                var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+                var req = new RequestTelemetry();
+                initializer.Initialize(req);
+
+                Assert.Equal("RoleNameEnv", req.Context.Cloud.RoleName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            }
+        }
+
+        [Fact]
+        public void InitializeFallsbackToEnvIfHostNameIsEmptyInHeader()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "RoleNameEnv");
+                var requestTelemetry = new RequestTelemetry();
+                var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
+
+                contextAccessor.HttpContext.Request.Headers.Add("WAS-DEFAULT-HOSTNAME", new string[] { string.Empty });
+
+                var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+
+                initializer.Initialize(requestTelemetry);
+
+                Assert.Equal("RoleNameEnv", requestTelemetry.Context.Cloud.RoleName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            }
+        }
+
+        [Fact]
+        public void InitializeSetsRoleNameFromHostNameHeader()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
+
+            contextAccessor.HttpContext.Request.Headers.Add("WAS-DEFAULT-HOSTNAME", new string[] { "MyAppServiceProd" });
+
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+
+            initializer.Initialize(requestTelemetry);
+
+            Assert.Equal("MyAppServiceProd", requestTelemetry.Context.Cloud.RoleName);
+        }
+
+        [Fact]
+        public void InitializeSetsRoleNameFromRequestTelemetryIfPresent()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            requestTelemetry.Context.Cloud.RoleName = "RoleNameOnRequest";
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
+
+            contextAccessor.HttpContext.Request.Headers.Add("WAS-DEFAULT-HOSTNAME", new string[] { "RoleNameOnHeader" });
+
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+
+            var evt = new EventTelemetry();
+            initializer.Initialize(evt);
+
+            Assert.Equal("RoleNameOnRequest", evt.Context.Cloud.RoleName);
+        }
+
+        [Fact]
+        public void InitializeSavesRoleNameIntoRequestFromHostNameHeader()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
+
+            contextAccessor.HttpContext.Request.Headers.Add("WAS-DEFAULT-HOSTNAME", new string[] { "MyAppServiceProd" });
+
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+
+            var evt = new EventTelemetry();
+            initializer.Initialize(evt);
+
+            Assert.Equal("MyAppServiceProd", evt.Context.Cloud.RoleName);
+            Assert.Equal("MyAppServiceProd", requestTelemetry.Context.Cloud.RoleName);
+        }
+
+        [Fact]
+        public void InitializeSetsRoleNameFromHostNameWithAzureWebsites()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
+
+            contextAccessor.HttpContext.Request.Headers.Add("WAS-DEFAULT-HOSTNAME", new string[] { "appserviceslottest-ppe.azurewebsites.net" });
+
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+
+            initializer.Initialize(requestTelemetry);
+
+            Assert.Equal("appserviceslottest-ppe", requestTelemetry.Context.Cloud.RoleName);
+        }
+
+        [Fact]
+        public void InitializeSetsRoleNameFromHostNameWithAzureWebsitesCustom()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
+
+            contextAccessor.HttpContext.Request.Headers.Add("WAS-DEFAULT-HOSTNAME", new string[] { "appserviceslottest-ppe.azurewebsites.us" });
+
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+            initializer.WebAppSuffix = ".azurewebsites.us";
+
+            initializer.Initialize(requestTelemetry);
+
+            Assert.Equal("appserviceslottest-ppe", requestTelemetry.Context.Cloud.RoleName);
+        }
+
+        [Fact]
+        public void InitializeDoesNotOverrideRoleName()
+        {
+            var requestTelemetry = new RequestTelemetry();
+            requestTelemetry.Context.Cloud.RoleName = "ExistingRoleName";
+            
+            var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
+            contextAccessor.HttpContext.Request.Headers.Add("WAS-DEFAULT-HOSTNAME", new string[] { "MyAppServiceProd" });
+
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
+
+            initializer.Initialize(requestTelemetry);
+
+            Assert.Equal("ExistingRoleName", requestTelemetry.Context.Cloud.RoleName);
+        }
+
+        [Fact]
+        public void InitializewithNoEnvToHostNameHeader()
+        {
+            var ac = new HttpContextAccessor { HttpContext = null };
+
+            var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(ac);
+
+            var requestTelemetry = new RequestTelemetry();
+            initializer.Initialize(requestTelemetry);
+            Assert.Null(requestTelemetry.Context.Cloud.RoleName);
+        }
+    }
+}

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AzureAppServiceRoleNameFromHostNameHeaderInitializerTests.cs
@@ -170,8 +170,6 @@
             var requestTelemetry = new RequestTelemetry();
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
 
-            contextAccessor.HttpContext.Features.Set<IHttpConnectionFeature>(new HttpConnectionFeature());
-           
             var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
 
             initializer.Initialize(requestTelemetry);
@@ -184,8 +182,6 @@
             {
                 Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "RoleNameEnv");
                 var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor();
-
-                contextAccessor.HttpContext.Features.Set<IHttpConnectionFeature>(new HttpConnectionFeature());
 
                 var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor);
                 var req = new RequestTelemetry();
@@ -300,6 +296,26 @@
             initializer.Initialize(requestTelemetry);
 
             Assert.Equal("appserviceslottest-ppe", requestTelemetry.Context.Cloud.RoleName);
+        }
+
+        [Fact]
+        public void InitializeSetsRoleNameFromEnvWithAzureWebsitesCustom()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", "appserviceslottest-ppe.azurewebsites.us");
+                var requestTelemetry = new RequestTelemetry();
+                var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(requestTelemetry);
+                var initializer = new AzureAppServiceRoleNameFromHostNameHeaderInitializer(contextAccessor, ".azurewebsites.us");
+
+                initializer.Initialize(requestTelemetry);
+
+                Assert.Equal("appserviceslottest-ppe", requestTelemetry.Context.Cloud.RoleName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_HOSTNAME", null);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fix Issue # https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1207

There'll be similar fix for Asp.Net Apps in https://github.com/microsoft/ApplicationInsights-dotnet-server repo as well.