### PR TITLE
refactor projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,9 @@
   </Target>
 
   <PropertyGroup>
+    <!-- EnlistmentRoot is used to determine where to put BIN and OBJ directories. -->
     <EnlistmentRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'EnlistmentRoot.marker'))</EnlistmentRoot>
+    <!-- SourceRoot is used to reference project dependencies (ex: *.props). -->
     <SourceRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'SourceRoot.marker'))</SourceRoot>
 
     <BinRoot>$(EnlistmentRoot)\..\bin</BinRoot>
@@ -30,7 +32,6 @@
 
     <IntermediateOutputPath>$(ObjRoot)\$(Configuration)\$(RelativeOutputPathBase)</IntermediateOutputPath>
     <IntermediateOutputPath>$([System.IO.Path]::GetFullPath( $(IntermediateOutputPath) ))\</IntermediateOutputPath>
-
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,9 +17,6 @@
 
     <RelativeOutputPathBase>$(MSBuildProjectDirectory.Substring($(SourceRoot.Length)))</RelativeOutputPathBase>
 
-    <!-- <BaseIntermediateOutputPath>$(EnlistmentRoot)\..\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath( $(BaseIntermediateOutputPath) ))</BaseIntermediateOutputPath> -->
-
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
 
     <OutputPath>$(BinRoot)\$(Configuration)\$(RelativeOutputPathBase)</OutputPath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="Info_DirectoryBuildProps"  BeforeTargets="Build" >
+    <Message Text="INFO) Directory.Build.props imported by $(MSBuildProjectName)." Importance="high"/>
+  </Target>
+
+  <PropertyGroup>
+    <EnlistmentRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'EnlistmentRoot.marker'))</EnlistmentRoot>
+    <SourceRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'SourceRoot.marker'))</SourceRoot>
+
+    <BinRoot>$(EnlistmentRoot)\..\bin</BinRoot>
+    <BinRoot>$([System.IO.Path]::GetFullPath( $(BinRoot) ))</BinRoot>
+    
+    <ObjRoot>$(EnlistmentRoot)\..\obj</ObjRoot>
+    <ObjRoot>$([System.IO.Path]::GetFullPath( $(ObjRoot) ))</ObjRoot>
+
+    <RelativeOutputPathBase>$(MSBuildProjectDirectory.Substring($(SourceRoot.Length)))</RelativeOutputPathBase>
+
+    <!-- <BaseIntermediateOutputPath>$(EnlistmentRoot)\..\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath( $(BaseIntermediateOutputPath) ))</BaseIntermediateOutputPath> -->
+
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+
+    <OutputPath>$(BinRoot)\$(Configuration)\$(RelativeOutputPathBase)</OutputPath>
+    <OutputPath>$([System.IO.Path]::GetFullPath( $(OutputPath) ))\</OutputPath>
+
+    <!-- Collect all NuGet packages in the same folder for convenience during testing -->
+    <PackageOutputDir>$(BinRoot)\$(Configuration)\NuGet</PackageOutputDir>
+    <PackageOutputPath>$(PackageOutputDir)</PackageOutputPath>
+
+    <AppxPackageDir>$(OutputPath)</AppxPackageDir>
+
+    <IntermediateOutputPath>$(ObjRoot)\$(Configuration)\$(RelativeOutputPathBase)</IntermediateOutputPath>
+    <IntermediateOutputPath>$([System.IO.Path]::GetFullPath( $(IntermediateOutputPath) ))\</IntermediateOutputPath>
+
+  </PropertyGroup>
+
+</Project>

--- a/Nupkg.props
+++ b/Nupkg.props
@@ -37,4 +37,20 @@
     <!-- <PackageTags>$(PackageTags) newTag1 newTag2</PackageTags> -->
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Disable auto generation of package attributes. This resolves the 'Duplicate attribute' error. 
+         Common cause is a hidden AssemblyInfo.cs file in a project -->
+
+    <!-- <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute> 
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute> -->
+    
+  </PropertyGroup>
+
 </Project>

--- a/Nupkg.props
+++ b/Nupkg.props
@@ -37,20 +37,4 @@
     <!-- <PackageTags>$(PackageTags) newTag1 newTag2</PackageTags> -->
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Disable auto generation of package attributes. This resolves the 'Duplicate attribute' error. 
-         Common cause is a hidden AssemblyInfo.cs file in a project -->
-
-    <!-- <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute> 
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute> -->
-    
-  </PropertyGroup>
-
 </Project>

--- a/Product.props
+++ b/Product.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SourceRoot)\Nupkg.props" />
+  <Import Project="$(SourceRoot)\Signing.props" Condition=" '$(OS)' == 'Windows_NT' " />
 
   <Target Name="Info_ProductProps"  BeforeTargets="Build" >
     <Message Text="INFO) Product.props imported by $(MSBuildProjectName)." Importance="high"/>
@@ -8,14 +9,6 @@
 
   <PropertyGroup>
     <VersionPrefix>2.12.0-beta1</VersionPrefix>
-<!-- 
-    <OutputPath Condition="'$(OutputPath)'=='' ">$(EnlistmentRoot)..\..\artifacts\src\$(MSBuildProjectName)</OutputPath>
-	  <IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\src\$(MSBuildProjectName)</IntermediateOutputPath> -->
   </PropertyGroup>
-
-  <ImportGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <!-- 1 file is required for signing: Signing.props -->
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Signing.props'))\Signing.props" />
-  </ImportGroup>
 
 </Project>

--- a/Product.props
+++ b/Product.props
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(SourceRoot)\Nupkg.props" />
+
+  <Target Name="Info_ProductProps"  BeforeTargets="Build" >
+    <Message Text="INFO) Product.props imported by $(MSBuildProjectName)." Importance="high"/>
+  </Target>
+
+  <PropertyGroup>
+    <VersionPrefix>2.12.0-beta1</VersionPrefix>
+<!-- 
+    <OutputPath Condition="'$(OutputPath)'=='' ">$(EnlistmentRoot)..\..\artifacts\src\$(MSBuildProjectName)</OutputPath>
+	  <IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\src\$(MSBuildProjectName)</IntermediateOutputPath> -->
+  </PropertyGroup>
+
+  <ImportGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <!-- 1 file is required for signing: Signing.props -->
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Signing.props'))\Signing.props" />
+  </ImportGroup>
+
+</Project>

--- a/Signing.props
+++ b/Signing.props
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="Info_SigningProps"  BeforeTargets="Build" >
+    <Message Text="INFO) Signing.props imported by $(MSBuildProjectName)." Importance="high"/>
+  </Target>
+
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\Keys\InternalKey.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(SourceRoot)\Keys\InternalKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublicRelease)' == 'True'">
     <DefineConstants>$(DefineConstants);PUBLIC_RELEASE</DefineConstants>
     <DelaySign>true</DelaySign>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\Keys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(SourceRoot)\Keys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <Target Name="AddToSign" AfterTargets="CopyFilesToOutputDirectory" >

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -1,16 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\Nupkg.props" />
+  <Import Project="$(SourceRoot)\Product.props" />
   
   <PropertyGroup>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore</AssemblyName>
-    <VersionPrefix>2.12.0-beta1</VersionPrefix>
     <LangVersion>7.2</LangVersion>
     <TargetFrameworks>netstandard2.0;net451;net46;netstandard1.6</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6;netstandard2.0</TargetFrameworks>
     
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>	
-	  <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\src\$(MSBuildProjectName)</OutputPath>
-	  <IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\src\$(MSBuildProjectName)</IntermediateOutputPath>
+	  
     <DefineConstants>$(DefineConstants);AI_ASPNETCORE_WEB;</DefineConstants>
   </PropertyGroup>
 
@@ -66,7 +64,6 @@
 
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 
-
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0-beta1-build4530" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.12.0-beta1-build5020" />
@@ -99,8 +96,4 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
-  <ImportGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <!-- 1 file is required for signing: Signing.props -->
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Signing.props'))\Signing.props" />
-  </ImportGroup>
 </Project>

--- a/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -6,9 +6,7 @@
     <LangVersion>7.2</LangVersion>
     <TargetFrameworks>netstandard2.0;net451;net46;netstandard1.6</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6;netstandard2.0</TargetFrameworks>
-    
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>	
-	  
     <DefineConstants>$(DefineConstants);AI_ASPNETCORE_WEB;</DefineConstants>
   </PropertyGroup>
 

--- a/src/Microsoft.ApplicationInsights.WorkerService/Microsoft.ApplicationInsights.WorkerService.csproj
+++ b/src/Microsoft.ApplicationInsights.WorkerService/Microsoft.ApplicationInsights.WorkerService.csproj
@@ -1,14 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\Nupkg.props" />
+  <Import Project="$(SourceRoot)\Product.props"/>
 
   <PropertyGroup>
     <AssemblyName>Microsoft.ApplicationInsights.WorkerService</AssemblyName>
-    <VersionPrefix>2.12.0-beta1</VersionPrefix>
     <LangVersion>7.2</LangVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\src\$(MSBuildProjectName)</OutputPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\src\$(MSBuildProjectName)</IntermediateOutputPath>
     <DefineConstants>$(DefineConstants);AI_ASPNETCORE_WORKER;</DefineConstants>
   </PropertyGroup>
 
@@ -71,10 +68,5 @@
     
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
   </ItemGroup>
-  
-  <ImportGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <!-- 1 file is required for signing: Signing.props -->
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Signing.props'))\Signing.props" />
-  </ImportGroup>
-  
+
 </Project>

--- a/src/Microsoft.ApplicationInsights.WorkerService/Microsoft.ApplicationInsights.WorkerService.csproj
+++ b/src/Microsoft.ApplicationInsights.WorkerService/Microsoft.ApplicationInsights.WorkerService.csproj
@@ -68,5 +68,4 @@
     
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
   </ItemGroup>
-
 </Project>

--- a/test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
+++ b/test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
@@ -12,8 +12,6 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>ApplicationInsightsTypes</PackageId>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-	<OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>	
-	<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
 	<BondOutputDirectory>$(MSBuildThisFileDirectory)\Generated</BondOutputDirectory>
 	<EnableDefaultItems Condition="$(OS) == 'Windows_NT'">false</EnableDefaultItems>
   </PropertyGroup>

--- a/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests10.csproj
+++ b/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests10.csproj
@@ -11,8 +11,6 @@
     <PackageId>EmptyApp.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <!--<RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.5</RuntimeFrameworkVersion>-->
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
-	<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
+++ b/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
@@ -10,8 +10,6 @@
     <PackageId>EmptyApp20.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
-	<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>    
 	<DependsOnNETStandard Condition=" '$(TargetFramework)' == 'net461'">true</DependsOnNETStandard>

--- a/test/FunctionalTestUtils/FunctionalTestUtils.csproj
+++ b/test/FunctionalTestUtils/FunctionalTestUtils.csproj
@@ -8,8 +8,6 @@
     <AssemblyName>FunctionalTestUtils</AssemblyName>        
     <PackageId>FunctionalTestUtils</PackageId>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-	<OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
-	<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
+++ b/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
@@ -8,8 +8,6 @@
     <AssemblyName>FunctionalTestUtils20</AssemblyName>    
     <PackageId>FunctionalTestUtils</PackageId>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
-	<OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>	
-	<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests10.csproj
+++ b/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests10.csproj
@@ -11,8 +11,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <UserSecretsId>aspnet-MVCFramework45.FunctionalTests-60cfc765-2dc9-454c-bb34-dc379ed92cd0</UserSecretsId>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.5</RuntimeFrameworkVersion>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
-	<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <DebugType>pdbonly</DebugType>

--- a/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
+++ b/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
@@ -11,8 +11,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <UserSecretsId>aspnet-MVCFramework45.FunctionalTests-60cfc765-2dc9-454c-bb34-dc379ed92cd0</UserSecretsId>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
-	<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <DebugType>pdbonly</DebugType>

--- a/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -13,8 +13,6 @@
     <PackageId>Microsoft.ApplicationInsights.AspNetCore.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.5</RuntimeFrameworkVersion>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
-	<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/test/Microsoft.ApplicationInsights.WorkerService.Tests/Microsoft.ApplicationInsights.WorkerService.Tests.csproj
+++ b/test/Microsoft.ApplicationInsights.WorkerService.Tests/Microsoft.ApplicationInsights.WorkerService.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestApp30.Tests/TestApp30.Tests30.csproj
+++ b/test/TestApp30.Tests/TestApp30.Tests30.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestApp30/TestApp30.csproj
+++ b/test/TestApp30/TestApp30.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebApi.FunctionalTests/WebApi.FunctionalTests10.csproj
+++ b/test/WebApi.FunctionalTests/WebApi.FunctionalTests10.csproj
@@ -11,8 +11,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.5</RuntimeFrameworkVersion>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
-	<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
+++ b/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
@@ -10,8 +10,6 @@
     <PackageId>WebApi20.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>    
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\test\$(MSBuildProjectName)</OutputPath>
-	<IntermediateOutputPath Condition="'$(IntermediateOutputPath)'=='' ">..\..\artifacts\obj\test\$(MSBuildProjectName)</IntermediateOutputPath>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>


### PR DESCRIPTION
https://github.com/microsoft/ApplicationInsights-dotnet/issues/1214
1. Reorganize individual repos. This is to ensure that there are no conflicting directories or file names and to guarantee no conflicts when migrating source. This will require some minor changes to existing build definitions.


**Changes**
remove "artifacts" directory.
Now using same bin and obj directories as all other repos.
